### PR TITLE
Minor fix for msg.release()

### DIFF
--- a/include/message.hh
+++ b/include/message.hh
@@ -296,7 +296,7 @@ namespace cmk {
         {
             pack_message(msg);
 
-            int msg_size = msg->total_size_;
+            auto msg_size = msg->total_size_;
 
             CmiSyncBroadcastAllAndFree(msg_size, (char*) msg.release());
         }
@@ -310,7 +310,7 @@ namespace cmk {
             {
                 pack_message(msg);
 
-                int msg_size = msg->total_size_;
+                auto msg_size = msg->total_size_;
 
                 CmiSyncSendAndFree(pe, msg_size, (char*) msg.release());
             }

--- a/include/message.hh
+++ b/include/message.hh
@@ -296,7 +296,9 @@ namespace cmk {
         {
             pack_message(msg);
 
-            CmiSyncBroadcastAllAndFree(msg->total_size_, (char*) msg.release());
+            int msg_size = msg->total_size_;
+
+            CmiSyncBroadcastAllAndFree(msg_size, (char*) msg.release());
         }
         else
         {
@@ -308,7 +310,9 @@ namespace cmk {
             {
                 pack_message(msg);
 
-                CmiSyncSendAndFree(pe, msg->total_size_, (char*) msg.release());
+                int msg_size = msg->total_size_;
+
+                CmiSyncSendAndFree(pe, msg_size, (char*) msg.release());
             }
         }
     }


### PR DESCRIPTION
This currently fails because I think the msg.release() is evaluated before the first argument