### PR TITLE
Add Tree Builder Skeleton

### DIFF
--- a/examples/basic/pgm.cc
+++ b/examples/basic/pgm.cc
@@ -31,8 +31,8 @@ struct foo : public cmk::chare<foo, int>
         CmiPrintf("ch%d@pe%d> %d+%d=%d\n", this->index(), CmiMyPe(), this->val,
             msg->val, this->val + msg->val);
         auto cb = cmk::callback<cmk::message>::construct<cmk::exit>(cmk::all);
-        this->element_proxy()
-            .contribute<cmk::message, cmk::nop>(std::move(msg), cb);
+        this->element_proxy().contribute<cmk::message, cmk::nop>(
+            std::move(msg), cb);
     }
 };
 
@@ -43,17 +43,16 @@ int main(int argc, char** argv)
     {
         // create a collection
         auto arr = cmk::collection_proxy<foo>::construct();
-        // for each pe...
-        for (auto i = 0; i < CmiNumPes(); i++)
+        // OVER DECOMPOSE!
+        auto n = 8 * CmiNumPes();
+        for (auto i = 0; i < n; i++)
         {
-            auto elt = arr[i];
-            // insert an element
-            elt.insert(cmk::make_message<test_message>(i));
-            // and send it a message
-            elt.send<test_message, &foo::bar>(
-                cmk::make_message<test_message>(i + 1));
+            arr[i].insert(cmk::make_message<test_message>(i));
         }
-        // currently does nothing, will unblock reductions
+        // then send 'em a buncha' messages
+        arr.broadcast<test_message, &foo::bar>(
+            cmk::make_message<test_message>(n));
+        // necessary to enable collective communication
         arr.done_inserting();
     }
     cmk::finalize();

--- a/examples/basic/pgm.cc
+++ b/examples/basic/pgm.cc
@@ -30,9 +30,9 @@ struct foo : public cmk::chare<foo, int>
     {
         CmiPrintf("ch%d@pe%d> %d+%d=%d\n", this->index(), CmiMyPe(), this->val,
             msg->val, this->val + msg->val);
-        // note -- this is a cross-pe reduction
-        // (cross-chare reductions not yet implemented)
-        cmk::reduce<cmk::message, cmk::nop, cmk::exit>(std::move(msg));
+        auto cb = cmk::callback<cmk::message>::construct<cmk::exit>(cmk::all);
+        this->element_proxy()
+            .contribute<cmk::message, cmk::nop>(std::move(msg), cb);
     }
 };
 

--- a/examples/cdt/pgm.cc
+++ b/examples/cdt/pgm.cc
@@ -8,137 +8,19 @@
  */
 
 #include <cmk.hh>
-
-// a chare that uses an int for its index
-class completion : public cmk::chare<completion, int>
-{
-public:
-    struct count;
-    using count_message = cmk::data_message<count>;
-    using detection_message = cmk::data_message<
-        std::tuple<cmk::collection_index_t, cmk::callback<cmk::message>>>;
-
-    struct status
-    {
-        cmk::message_ptr<detection_message> msg;
-        std::int64_t lcount;
-        bool complete;
-
-        status(cmk::message_ptr<detection_message>&& msg_)
-          : msg(std::move(msg_))
-          , lcount(0)
-          , complete(false)
-        {
-        }
-    };
-
-    struct count
-    {
-        cmk::collection_index_t target;
-        std::int64_t gcount;
-
-        count(cmk::collection_index_t target_, std::int64_t gcount_)
-          : target(target_)
-          , gcount(gcount_)
-        {
-        }
-
-        // used by the cmk::add operator
-        count& operator+=(const count& other)
-        {
-            this->gcount += other.gcount;
-            return *this;
-        }
-    };
-
-    cmk::collection_map<status> statii;
-
-    completion(void) = default;
-
-    // obtain the completion status of a collection
-    // (setting a callback message if one isn't present)
-    status& get_status(
-        cmk::collection_index_t idx, cmk::message_ptr<detection_message>& msg)
-    {
-        auto find = this->statii.find(idx);
-        if (find == std::end(this->statii))
-        {
-            find = this->statii.emplace(idx, std::move(msg)).first;
-        }
-        else if (msg)
-        {
-            find->second.msg = std::move(msg);
-        }
-        return find->second;
-    }
-
-    // starts completion detection on _this_ pe
-    // (all pes need to start it for it to complete)
-    void start_detection(cmk::message_ptr<detection_message>&& msg)
-    {
-        auto& val = msg->value();
-        auto& idx = std::get<0>(val);
-        auto& status = this->get_status(idx, msg);
-        if (status.complete)
-        {
-            // the root invokes the callback
-            if (this->index() == 0)
-            {
-                std::get<1>(val).send(std::move(msg));
-            }
-            // and, just to be safe, reset our status!
-            new (&status) completion::status(nullptr);
-        }
-        else
-        {
-            // contribute to the all_reduce with other participants
-            auto cb =
-                this->collection_proxy()
-                    .callback<count_message, &completion::receive_count_>();
-            auto count = cmk::make_message<count_message>(idx, status.lcount);
-            this->element_proxy()
-                .contribute<count_message,
-                    cmk::add<typename count_message::type>>(
-                    std::move(count), cb);
-        }
-    }
-
-    // produce one or more events
-    void produce(cmk::collection_index_t idx, std::int64_t n = 1)
-    {
-        cmk::message_ptr<detection_message> nil;
-        this->get_status(idx, nil).lcount += n;
-    }
-
-    // consume one or more events
-    void consume(cmk::collection_index_t idx, std::int64_t n = 1)
-    {
-        this->produce(idx, -n);
-    }
-
-private:
-    // receive the global-count from the all-reduce
-    // and update the status accordingly
-    void receive_count_(cmk::message_ptr<count_message>&& msg)
-    {
-        auto& gcount = msg->value();
-        cmk::message_ptr<detection_message> nil;
-        auto& status = this->get_status(gcount.target, nil);
-        status.complete = (gcount.gcount == 0);
-        this->start_detection(std::move(status.msg));
-    }
-};
+#include <completion.hh>
 
 // a callback to resume the main thread
 void resume_main_(cmk::message_ptr<>&& msg);
 
 struct test : cmk::chare<test, int>
 {
-    cmk::group_proxy<completion> detector;
+    using completion_proxy = cmk::group_proxy<cmk::completion>;
+
+    completion_proxy detector;
     bool detection_started_;
 
-    test(
-        cmk::message_ptr<cmk::data_message<cmk::group_proxy<completion>>>&& msg)
+    test(cmk::message_ptr<cmk::data_message<completion_proxy>>&& msg)
       : detector(msg->value())
     {
     }
@@ -188,12 +70,12 @@ struct test : cmk::chare<test, int>
                 // goal : wake up the main pe!
                 auto cb =
                     cmk::callback<cmk::message>::construct<resume_main_>(0);
-                auto dm = cmk::make_message<completion::detection_message>(
+                auto dm = cmk::make_message<cmk::completion::detection_message>(
                     this->collection(), cb);
                 // (each pe could start its own completion detection
                 //  but this checks that broadcasts are working!)
-                detector.broadcast<completion::detection_message,
-                    &completion::start_detection>(std::move(dm));
+                detector.broadcast<cmk::completion::detection_message,
+                    &cmk::completion::start_detection>(std::move(dm));
 
                 detection_started_ = true;
             }
@@ -217,7 +99,7 @@ int main(int argc, char** argv)
         th = CthSelf();
         CmiAssert(th && CthIsSuspendable(th));
         // establish detector and participant groups
-        auto detector = cmk::group_proxy<completion>::construct();
+        auto detector = cmk::group_proxy<cmk::completion>::construct();
         auto dm =
             cmk::make_message<cmk::data_message<decltype(detector)>>(detector);
         auto elts = cmk::group_proxy<test>::construct(std::move(dm));

--- a/examples/pingpong/pgm.cc
+++ b/examples/pingpong/pgm.cc
@@ -106,8 +106,8 @@ int main(int argc, char** argv)
         // create a collection
         auto grp = cmk::group_proxy<pingpong>::construct();
         // get the runtime parameters
-        std::size_t sz = (argc >= 2) ? atoll(argv[1]) : 4096;
-        std::size_t nIts = (argc >= 3) ? atoll(argv[2]) : 128;
+        std::size_t sz = (argc >= 2 && argv) ? atoll(argv[1]) : 4096;
+        std::size_t nIts = (argc >= 3 && argv) ? atoll(argv[2]) : 128;
         CmiPrintf(
             "main> pingpong with %luB payload and %lu iterations\n", sz, nIts);
         // allocate the launch pack

--- a/include/callback.hh
+++ b/include/callback.hh
@@ -52,6 +52,10 @@ namespace cmk {
         }
 
     public:
+        callback(void) = default;
+        callback(callback<Message>&&) = default;
+        callback(const callback<Message>&) = default;
+
         template <typename T>
         friend class collection_proxy_base_;
 
@@ -68,7 +72,7 @@ namespace cmk {
             this->imprint(msg->dst_);
         }
 
-        void send(message_ptr<Message>&& msg)
+        void send(message_ptr<Message>&& msg) const
         {
             this->imprint(msg);
             cmk::send(std::move(msg));
@@ -79,6 +83,11 @@ namespace cmk {
         {
             return callback<Message>(
                 callback_helper_<Message, Callback>::id_, pe);
+        }
+
+        operator bool(void) const
+        {
+            return (bool) this->dst_;
         }
     };
 }    // namespace cmk

--- a/include/chare.hh
+++ b/include/chare.hh
@@ -52,16 +52,34 @@ namespace cmk {
     template <typename T, template <class> class Mapper>
     class collection;
 
+    struct association_
+    {
+        std::vector<chare_index_t> parent;
+        std::vector<chare_index_t> children;
+        bool valid_parent;
+
+        void put_child(const chare_index_t& index)
+        {
+            this->children.emplace_back(index);
+        }
+
+        void put_parent(const chare_index_t& index)
+        {
+            this->valid_parent = true;
+            this->parent.emplace_back(index);
+        }
+    };
+
     struct reducer_
     {
         std::vector<chare_index_t> upstream;
         std::vector<chare_index_t> downstream;
         std::vector<message_ptr<message>> received;
 
-        reducer_(
-            std::vector<chare_index_t>&& up, std::vector<chare_index_t>&& down)
-          : upstream(std::move(up))
-          , downstream(std::move(down))
+        reducer_(const std::vector<chare_index_t>& up,
+            const std::vector<chare_index_t>& down)
+          : upstream(up)
+          , downstream(down)
         {
         }
 
@@ -83,12 +101,22 @@ namespace cmk {
         using reducer_map_t = std::unordered_map<bcast_id_t, reducer_>;
         reducer_map_t reducers_;
 
+        std::unique_ptr<cmk::association_> association_;
+
+        std::size_t num_children_(void) const
+        {
+            return this->association_ ? this->association_->children.size() : 0;
+        }
+
     public:
         template <typename T, typename Index>
         friend class chare;
 
         template <typename T, template <class> class Mapper>
         friend class collection;
+
+        template <typename T, template <class> class Mapper>
+        friend class collection_bridge_;
 
         template <typename T, typename Enable>
         friend struct property_setter_;

--- a/include/cmk.impl.hh
+++ b/include/cmk.impl.hh
@@ -155,6 +155,29 @@ namespace cmk {
         register_function_<Message, callback_fn_t, Fn>(
             CsvAccess(callback_table_));
 
+    inline completion* system_detector_(void)
+    {
+        collection_index_t sys{.pe_ = cmk::all, .id_ = 0};
+        auto& table = CpvAccess(collection_table_);
+        auto find = table.find(sys);
+        collection_base_* loc = nullptr;
+        if (find == std::end(table))
+        {
+            collection_options<int> opts(CmiNumPes());
+            auto msg = cmk::make_message<message>();
+            new (&msg->dst_) destination(
+                sys, chare_bcast_root_, constructor<completion, void>());
+            loc =
+                new collection<completion, group_mapper>(sys, opts, msg.get());
+            table.emplace(sys, loc);
+        }
+        else
+        {
+            loc = find->second.get();
+        }
+        auto idx = index_view<int>::encode(CmiMyPe());
+        return loc->template lookup<completion>(idx);
+    }
 }    // namespace cmk
 
 #endif

--- a/include/collection.impl.hh
+++ b/include/collection.impl.hh
@@ -104,6 +104,10 @@ namespace cmk {
         }
     };
 
+    // this more or less implements the logic of hypercomm's
+    // tree builder... the code there is better commented for the time being:
+    // https://github.com/jszaday/hypercomm/blob/main/include/hypercomm/tree_builder/tree_builder.hpp
+    // TODO ( copy the comments from there)
     template <typename T, template <class> class Mapper>
     class collection_bridge_ : public collection_base_
     {

--- a/include/collection.impl.hh
+++ b/include/collection.impl.hh
@@ -1,0 +1,424 @@
+#ifndef __CMK_COLLECTION_IMPL_HH__
+#define __CMK_COLLECTION_IMPL_HH__
+
+#include "completion.hh"
+#include "locmgr.hh"
+#include "math.hh"
+
+#include <functional>
+
+namespace cmk {
+    class collection_base_
+    {
+    protected:
+        collection_index_t id_;
+
+        virtual void on_insertion_complete(void) = 0;
+
+    public:
+        virtual ~collection_base_() = default;
+
+        collection_base_(const collection_index_t& id)
+          : id_(id)
+        {
+        }
+
+        virtual void* lookup(const chare_index_t&) = 0;
+        virtual void deliver(message_ptr<>&& msg, bool immediate) = 0;
+        virtual void contribute(message_ptr<>&& msg) = 0;
+
+        template <typename T>
+        inline T* lookup(const chare_index_t& idx)
+        {
+            return static_cast<T*>(this->lookup(idx));
+        }
+    };
+
+    // implements mapper-specific behaviors for
+    // chare-collections -- i.e., listeners and spanning tree construction
+    template <typename T, template <class> class Mapper>
+    class collection_bridge_;
+
+    template <typename T>
+    class collection_bridge_<T, group_mapper> : public collection_base_
+    {
+    protected:
+        std::unordered_map<chare_index_t, std::unique_ptr<T>> chares_;
+        chare_index_t endpoint_;
+
+        using index_type = index_for_t<T>;
+        group_mapper<index_type> locmgr_;
+
+        collection_bridge_(const collection_index_t& id)
+          : collection_base_(id)
+          , endpoint_(index_view<index_type>::encode(0))
+        {
+        }
+
+        void on_chare_arrival(T* obj, bool created)
+        {
+            auto* elt = static_cast<chare_base_*>(obj);
+            auto& assoc = elt->association_;
+            if (created)
+            {
+                auto pe = this->locmgr_.pe_for(elt->index_);
+                auto n_children = CmiNumSpanTreeChildren(pe);
+                CmiAssert(!assoc && (pe == CmiMyPe()));
+                assoc.reset(new association_);
+                if (n_children > 0)
+                {
+                    // copied from qd.h -- memcheck seems to be legacy?
+                    std::vector<index_type> child_pes(n_children);
+                    CmiSpanTreeChildren(pe, child_pes.data());
+                    auto& children = assoc->children;
+                    children.reserve(n_children);
+                    std::transform(std::begin(child_pes), std::end(child_pes),
+                        std::back_inserter(children),
+                        index_view<index_type>::encode);
+                    CmiAssert(n_children == children.size());
+                }
+                auto parent = CmiSpanTreeParent(pe);
+                if (parent >= 0)
+                {
+                    assoc->put_parent(index_view<index_type>::encode(parent));
+                }
+                else
+                {
+                    assoc->valid_parent = true;
+                }
+            }
+        }
+
+        std::nullptr_t ready_callback_(void) {}
+
+        bool is_inserting(void) const
+        {
+            return false;
+        }
+
+        void set_insertion_status(bool status, std::nullptr_t) {}
+
+        const chare_index_t* root(void) const
+        {
+            return &(this->endpoint_);
+        }
+    };
+
+    template <typename T, template <class> class Mapper>
+    class collection_bridge_ : public collection_base_
+    {
+        using self_type = collection_bridge_<T, Mapper>;
+        using element_type = chare_base_*;
+
+    public:
+        static entry_id_t receive_status(void)
+        {
+            using receiver_type = member_fn_t<self_type, data_message<bool>>;
+            return cmk::entry<receiver_type,
+                (receiver_type) &self_type::receive_status>();
+        }
+
+    protected:
+        using index_type = index_for_t<T>;
+
+        std::unordered_map<chare_index_t, std::unique_ptr<T>> chares_;
+        locmgr<Mapper<index_type>> locmgr_;
+        chare_index_t endpoint_;
+
+        collection_bridge_(const collection_index_t& id)
+          : collection_base_(id)
+          , endpoint_(chare_bcast_root_)
+        {
+        }
+
+        bool is_inserting(void) const
+        {
+            return this->is_inserting_;
+        }
+
+        void on_chare_arrival(T* obj, bool created)
+        {
+            if (created)
+            {
+                this->associate(static_cast<element_type>(obj));
+            }
+        }
+
+        void set_insertion_status(bool status, const callback<message>& cb)
+        {
+            if (status)
+            {
+                this->is_inserting_ = status;
+
+                if ((bool) cb)
+                {
+                    CmiAbort("not implemented");
+                }
+            }
+            else if ((bool) cb)
+            {
+                auto msg = cmk::make_message<completion::detection_message>(
+                    this->id_, cb);
+                system_detector_()->start_detection(std::move(msg));
+            }
+            else
+            {
+                this->is_inserting_ = false;
+            }
+        }
+
+        const chare_index_t* root(void) const
+        {
+            if (this->is_inserting_ || (this->endpoint_ == chare_bcast_root_))
+            {
+                return nullptr;
+            }
+            else
+            {
+                return &(this->endpoint_);
+            }
+        }
+
+        callback<message> ready_callback_(void)
+        {
+            return callback<message>::construct<&(
+                self_type::insertion_complete_)>(cmk::all);
+        }
+
+    private:
+        void receive_status(message_ptr<data_message<bool>>&& msg)
+        {
+            if (msg->value())
+            {
+                CmiAbort("not implemented");
+            }
+            else
+            {
+                this->set_insertion_status(false, this->ready_callback_());
+            }
+        }
+
+        static void insertion_complete_(message_ptr<>&& msg)
+        {
+            using dm_t = completion::detection_message;
+            auto dm_kind = message_helper_<dm_t>::kind_;
+            auto* dm = (dm_kind == msg->kind_) ? static_cast<dm_t*>(msg.get()) :
+                                                 nullptr;
+            auto& id = std::get<0>(dm->value());
+            auto* self = static_cast<self_type*>(cmk::lookup(id));
+            CmiAssert(self->is_inserting_);
+            self->is_inserting_ = false;
+            self->on_insertion_complete();
+        }
+
+        bool is_inserting_;
+
+        struct facade_
+        {
+            int pe_;
+            element_type elt_;
+
+            facade_(int pe)
+              : elt_(nullptr)
+              , pe_(pe)
+            {
+            }
+            facade_(element_type elt)
+              : elt_(elt)
+              , pe_(cmk::all)
+            {
+            }
+        };
+
+        using index_message = data_message<std::pair<int, chare_index_t>>;
+
+        template <typename Message, member_fn_t<self_type, Message> Fn,
+            typename... Args>
+        cmk::message_ptr<Message> make_message(Args&&... args)
+        {
+            auto msg = cmk::make_message<Message>(std::forward<Args>(args)...);
+            auto entry = cmk::entry<member_fn_t<self_type, Message>, Fn>();
+            new (&(msg->dst_)) destination(this->id_, chare_bcast_root_, entry);
+            msg->for_collection() = true;
+            return std::move(msg);
+        }
+
+        void produce(std::int64_t count = 1)
+        {
+            if (count != 0)
+            {
+                system_detector_()->produce(this->id_, count);
+            }
+        }
+
+        void consume(void)
+        {
+            this->produce(-1);
+        }
+
+        void receive_upstream(cmk::message_ptr<index_message>&& msg)
+        {
+            auto& val = msg->value();
+            auto& src = val.first;
+            auto& idx = val.second;
+            this->register_upstream(facade_(src), idx);
+            this->consume();
+        }
+
+        void receive_downstream(cmk::message_ptr<index_message>&& msg)
+        {
+            auto& val = msg->value();
+            auto& src = val.first;
+            auto& idx = val.second;
+            auto target = this->register_downstream(facade_(src), idx);
+            if (target == nullptr)
+            {
+                this->consume();
+            }
+            else
+            {
+                auto msg = this->make_message<index_message,
+                    &self_type::receive_upstream>(CmiMyPe(), target->index_);
+                send_helper_(src, std::move(msg));
+            }
+        }
+
+        void receive_endpoint(cmk::message_ptr<index_message>&& msg)
+        {
+            auto& val = msg->value();
+            auto& src = val.first;
+            auto& idx = val.second;
+            this->register_endpoint(facade_(src), idx);
+        }
+
+        void register_endpoint(const facade_& f, const chare_index_t& idx)
+        {
+            this->endpoint_ = idx;
+            auto elt =
+                f.elt_ ? f.elt_ : this->template lookup<chare_base_>(idx);
+            CmiAssert((elt == nullptr) || (idx == elt->index_));
+            if (elt)
+            {
+                elt->association_->valid_parent = true;
+            }
+            auto mine = CmiMyPe();
+            auto leaves = binary_tree::leaves(mine, CmiNumPes());
+            for (auto& leaf : leaves)
+            {
+                auto msg = this->make_message<index_message,
+                    &self_type::receive_endpoint>(CmiMyPe(), idx);
+                send_helper_(leaf, std::move(msg));
+            }
+            this->produce((std::int64_t) leaves.size() - 1);
+        }
+
+        void send_downstream(const facade_& f, const chare_index_t& idx)
+        {
+            // this should not occur under normal circumstances since
+            // all messages _should_ have valid destinations
+            CmiAbort("not implemented");
+        }
+
+        void send_upstream(const facade_& f, const chare_index_t& idx)
+        {
+            auto mine = CmiMyPe();
+            auto parent = binary_tree::parent(mine);
+            if (parent >= 0)
+            {
+                auto src = f.elt_ == nullptr ? f.pe_ : mine;
+                auto msg = this->make_message<index_message,
+                    &self_type::receive_downstream>(src, idx);
+                send_helper_(parent, std::move(msg));
+            }
+            else
+            {
+                this->register_endpoint(f, idx);
+            }
+            this->produce();
+        }
+
+        element_type register_downstream(
+            const facade_& f, const chare_index_t& idx)
+        {
+            element_type min = nullptr;
+            for (auto& pair : this->chares_)
+            {
+                auto& ch = pair.second;
+                if (idx == ch->index_)
+                {
+                    continue;
+                }
+                else if ((min == nullptr) ||
+                    (min->num_children_() > ch->num_children_()))
+                {
+                    min = ch.get();
+                }
+            }
+
+            if (min == nullptr)
+            {
+                this->send_upstream(f, idx);
+
+                return nullptr;
+            }
+            else
+            {
+                min->association_->put_child(idx);
+
+                return min;
+            }
+        }
+
+        element_type register_upstream(
+            const facade_& f, const chare_index_t& idx)
+        {
+            element_type found = nullptr;
+            for (auto& pair : this->chares_)
+            {
+                auto& ch = pair.second;
+                if (idx == ch->index_)
+                {
+                    continue;
+                }
+                else if (!(ch->association_ && ch->association_->valid_parent))
+                {
+                    found = ch.get();
+                }
+            }
+
+            if (found == nullptr)
+            {
+                this->send_downstream(f, idx);
+
+                return nullptr;
+            }
+            else
+            {
+                found->association_->put_parent(idx);
+
+                return found;
+            }
+        }
+
+        void associate(element_type elt)
+        {
+            auto& assoc = elt->association_;
+            if (this->is_inserting_ && !assoc)
+            {
+                assoc.reset(new association_);
+                auto* target =
+                    this->register_downstream(facade_(elt), elt->index_);
+                if (target != nullptr)
+                {
+                    assoc->put_parent(target->index_);
+                }
+            }
+            else
+            {
+                CmiAssertMsg(assoc, "dynamic insertions must be associated");
+            }
+        }
+    };
+}    // namespace cmk
+
+#endif

--- a/include/completion.hh
+++ b/include/completion.hh
@@ -1,0 +1,133 @@
+#ifndef __CMK_COMPLETION_HH__
+#define __CMK_COMPLETION_HH__
+
+#include "core.hh"
+#include "message.hh"
+#include "proxy.hh"
+#include "reduction.hh"
+
+namespace cmk {
+    // a chare that uses an int for its index
+    class completion : public chare<completion, int>
+    {
+    public:
+        struct count;
+        using count_message = data_message<count>;
+        using detection_message =
+            data_message<std::tuple<collection_index_t, callback<message>>>;
+
+        struct status
+        {
+            message_ptr<detection_message> msg;
+            std::int64_t lcount;
+            bool complete;
+
+            status(message_ptr<detection_message>&& msg_)
+              : msg(std::move(msg_))
+              , lcount(0)
+              , complete(false)
+            {
+            }
+        };
+
+        struct count
+        {
+            collection_index_t target;
+            std::int64_t gcount;
+
+            count(collection_index_t target_, std::int64_t gcount_)
+              : target(target_)
+              , gcount(gcount_)
+            {
+            }
+
+            // used by the add operator
+            count& operator+=(const count& other)
+            {
+                this->gcount += other.gcount;
+                return *this;
+            }
+        };
+
+        collection_map<status> statii;
+
+        completion(void) = default;
+
+        // obtain the completion status of a collection
+        // (setting a callback message if one isn't present)
+        status& get_status(
+            collection_index_t idx, message_ptr<detection_message>& msg)
+        {
+            auto find = this->statii.find(idx);
+            if (find == std::end(this->statii))
+            {
+                find = this->statii.emplace(idx, std::move(msg)).first;
+            }
+            else if (msg)
+            {
+                find->second.msg = std::move(msg);
+            }
+            return find->second;
+        }
+
+        // starts completion detection on _this_ pe
+        // (all pes need to start it for it to complete)
+        void start_detection(message_ptr<detection_message>&& msg)
+        {
+            auto& val = msg->value();
+            auto& idx = std::get<0>(val);
+            auto& status = this->get_status(idx, msg);
+            if (status.complete)
+            {
+                // the root invokes the callback
+                if (this->index() == 0)
+                {
+                    std::get<1>(val).send(std::move(msg));
+                }
+                // and, just to be safe, reset our status!
+                new (&status) completion::status(nullptr);
+            }
+            else
+            {
+                // contribute to the all_reduce with other participants
+                auto cb =
+                    this->collection_proxy()
+                        .callback<count_message, &completion::receive_count_>();
+                auto count = make_message<count_message>(idx, status.lcount);
+                this->element_proxy()
+                    .contribute<count_message,
+                        add<typename count_message::type>>(
+                        std::move(count), cb);
+            }
+        }
+
+        // produce one or more events
+        void produce(collection_index_t idx, std::int64_t n = 1)
+        {
+            message_ptr<detection_message> nil;
+            this->get_status(idx, nil).lcount += n;
+        }
+
+        // consume one or more events
+        void consume(collection_index_t idx, std::int64_t n = 1)
+        {
+            this->produce(idx, -n);
+        }
+
+    private:
+        // receive the global-count from the all-reduce
+        // and update the status accordingly
+        void receive_count_(message_ptr<count_message>&& msg)
+        {
+            auto& gcount = msg->value();
+            message_ptr<detection_message> nil;
+            auto& status = this->get_status(gcount.target, nil);
+            status.complete = (gcount.gcount == 0);
+            this->start_detection(std::move(status.msg));
+        }
+    };
+
+    inline completion* system_detector_(void);
+}    // namespace cmk
+
+#endif

--- a/include/destination.hh
+++ b/include/destination.hh
@@ -57,6 +57,9 @@ namespace cmk {
                 .bcast = 0};
         }
 
+        destination(destination&& dst) = default;
+        destination(const destination& dst) = default;
+
         inline s_callback_fn_& callback_fn(void)
         {
             CmiAssert(this->kind_ == kCallback);
@@ -88,6 +91,11 @@ namespace cmk {
             default:
                 return false;
             }
+        }
+
+        operator bool(void) const
+        {
+            return !(this->kind_ == kInvalid);
         }
 
         operator std::string(void) const

--- a/include/ep.hh
+++ b/include/ep.hh
@@ -83,6 +83,9 @@ namespace cmk {
     {
         return entry_fn_helper_<(&call_constructor_<T, Message>), true>::id_;
     }
+
+    template <typename T, template <class> class Mapper>
+    inline collection_kind_t collection_kind(void);
 }    // namespace cmk
 
 #endif

--- a/include/locmgr.hh
+++ b/include/locmgr.hh
@@ -43,70 +43,7 @@ namespace cmk {
     template <typename Mapper>
     class locmgr : public locmgr_base_<Mapper>
     {
-    public:
-        // NOTE ( these methods will have to be expanded if/when
-        //        we add support for sections. )
-        chare_index_t root(void) const
-        {
-            CmiAbort("not implemented.");
-        }
-
-        std::vector<chare_index_t> upstream(const chare_index_t& idx) const
-        {
-            CmiAbort("not implemented.");
-        }
-
-        std::vector<chare_index_t> downstream(const chare_index_t& idx) const
-        {
-            CmiAbort("not implemented.");
-        }
-    };
-
-    template <>
-    class locmgr<group_mapper<int>> : public locmgr_base_<group_mapper<int>>
-    {
-    public:
-        chare_index_t root(void) const
-        {
-            CmiAssert(CmiSpanTreeParent(0) < 0);
-            return index_view<int>::encode(0);
-        }
-
-        std::vector<chare_index_t> upstream(const chare_index_t& idx) const
-        {
-            auto pe = this->pe_for(idx);
-            auto n_children = CmiNumSpanTreeChildren(pe);
-            if (n_children > 0)
-            {
-                // copied from qd.h -- memcheck seems to be legacy?
-                std::vector<int> child_pes(n_children);
-                _MEMCHECK(child_pes.data());
-                CmiSpanTreeChildren(CmiMyPe(), child_pes.data());
-                std::vector<chare_index_t> children;
-                children.reserve(n_children);
-                std::transform(std::begin(child_pes), std::end(child_pes),
-                    std::back_inserter(children), index_view<int>::encode);
-                return children;
-            }
-            else
-            {
-                return {};
-            }
-        }
-
-        std::vector<chare_index_t> downstream(const chare_index_t& idx) const
-        {
-            auto pe = this->pe_for(idx);
-            auto parent = CmiSpanTreeParent(pe);
-            if (parent >= 0)
-            {
-                return {index_view<int>::encode(parent)};
-            }
-            else
-            {
-                return {};
-            }
-        }
+        // TODO ( determine what should go here... )
     };
 }    // namespace cmk
 

--- a/include/math.hh
+++ b/include/math.hh
@@ -1,0 +1,43 @@
+#ifndef __CMK_MATH_HH__
+#define __CMK_MATH_HH__
+
+#include <vector>
+
+namespace cmk { namespace binary_tree {
+    template <typename T>
+    inline T left_child(const T& i)
+    {
+        return (2 * i) + 1;
+    }
+
+    template <typename T>
+    inline T right_child(const T& i)
+    {
+        return (2 * i) + 2;
+    }
+
+    template <typename T>
+    inline T parent(const T& i)
+    {
+        return (i > 0) ? ((i - 1) / 2) : -1;
+    }
+
+    template <typename T>
+    std::vector<T> leaves(const T& which, const T& max)
+    {
+        auto left = left_child(which);
+        auto right = right_child(which);
+        std::vector<T> res;
+        if (left >= 0 && left < max)
+        {
+            res.push_back(left);
+        }
+        if (right >= 0 && right < max)
+        {
+            res.push_back(right);
+        }
+        return std::move(res);
+    }
+}}    // namespace cmk::binary_tree
+
+#endif

--- a/include/message.hh
+++ b/include/message.hh
@@ -67,6 +67,7 @@ namespace cmk {
         static constexpr auto has_continuation_ = has_combiner_ + 1;
         static constexpr auto has_collection_kind_ = has_continuation_ + 1;
         static constexpr auto is_packed_ = has_collection_kind_ + 1;
+        static constexpr auto for_collection_ = is_packed_ + 1;
 
     public:
         using flag_type = std::bitset<8>::reference;
@@ -113,6 +114,11 @@ namespace cmk {
         flag_type has_combiner(void)
         {
             return this->flags_[has_combiner_];
+        }
+
+        flag_type for_collection(void)
+        {
+            return this->flags_[for_collection_];
         }
 
         flag_type has_continuation(void)

--- a/include/reduction.hh
+++ b/include/reduction.hh
@@ -7,21 +7,7 @@
 // TODO ( converse collectives should be isolated/removed )
 
 namespace cmk {
-    void* converse_combiner_(int* size, void* local, void** remote, int count)
-    {
-        message_ptr<> lhs(static_cast<message*>(local));
-        auto comb = combiner_for(lhs);
-        CmiEnforce(comb != nullptr);
-        for (auto i = 0; i < count; i++)
-        {
-            auto& msg = remote[i];
-            message_ptr<> rhs(reinterpret_cast<message*>(msg));
-            CmiReference(msg);    // yielding will call free!
-            lhs = comb(std::move(lhs), std::move(rhs));
-        }
-        *size = (int) lhs->total_size_;
-        return lhs.release();
-    }
+    void* converse_combiner_(int* size, void* local, void** remote, int count);
 
     template <typename Message, combiner_fn_t<Message> Combiner,
         callback_fn_t<Message> Callback>
@@ -36,7 +22,8 @@ namespace cmk {
         CmiReduce(msg.release(), sz, converse_combiner_);
     }
 
-    message_ptr<> nop(message_ptr<>&& msg, message_ptr<>&&)
+    template <typename T = message>
+    message_ptr<T> nop(message_ptr<T>&& msg, message_ptr<T>&&)
     {
         return std::move(msg);
     }


### PR DESCRIPTION
This enables broadcasts and reductions on chare-arrays via an approximation of Hypercomm's spanning-tree building scheme. 

Things still not yet supported:

- Chare deletion (not supported in general)
- Dynamic re-association (no migratibility, no problems)
- Starting insertion phases (no user-accessible `begin_inserting` API)