### PR TITLE
Quick Fixes to Enable Building w/ Clang

### DIFF
--- a/include/collection.impl.hh
+++ b/include/collection.impl.hh
@@ -89,7 +89,10 @@ namespace cmk {
             }
         }
 
-        std::nullptr_t ready_callback_(void) {}
+        std::nullptr_t ready_callback_(void)
+        {
+            return nullptr;
+        }
 
         bool is_inserting(void) const
         {
@@ -118,8 +121,7 @@ namespace cmk {
         static entry_id_t receive_status(void)
         {
             using receiver_type = member_fn_t<self_type, data_message<bool>>;
-            return cmk::entry<receiver_type,
-                (receiver_type) &self_type::receive_status>();
+            return cmk::entry<receiver_type, &self_type::receive_status>();
         }
 
     protected:
@@ -185,8 +187,8 @@ namespace cmk {
 
         callback<message> ready_callback_(void)
         {
-            return callback<message>::construct<&(
-                self_type::insertion_complete_)>(cmk::all);
+            return callback<message>::construct<
+                &self_type::insertion_complete_>(cmk::all);
         }
 
     private:

--- a/include/common.hh
+++ b/include/common.hh
@@ -34,7 +34,7 @@ namespace cmk {
 
     struct collection_index_t
     {
-        std::uint32_t pe_;
+        std::int32_t pe_;
         std::uint32_t id_;
 
         inline bool operator==(const collection_index_t& other) const

--- a/include/proxy.hh
+++ b/include/proxy.hh
@@ -171,8 +171,8 @@ namespace cmk {
     protected:
         static void next_index_(collection_index_t& idx)
         {
-            new (&idx) collection_index_t{(std::uint32_t) CmiMyPe(),
-                CpvAccess(local_collection_count_)++};
+            new (&idx) collection_index_t{
+                CmiMyPe(), CpvAccess(local_collection_count_)++};
         }
     };
 


### PR DESCRIPTION
Note, there are still warnings of the following sorts generated:
```
In file included from ../../src/core.cc:3:
In file included from ../../include/collection.hh:4:
In file included from ../../include/collection.impl.hh:4:
In file included from ../../include/completion.hh:6:
In file included from ../../include/proxy.hh:6:
../../include/ep.hh:41:55: warning: instantiation of variable 'cmk::entry_fn_helper_<&cmk::entry_fn_impl_<void (cmk::completion::*)(std::unique_ptr<cmk::data_message<cmk::completion::count>> &&), &cmk::completion::receive_count_>::call_, false>::id_' required here, but no definition is available [-Wundefined-var-template]
            return entry_fn_helper_<(&call_), false>::id_;
                                                      ^
../../include/ep.hh:78:38: note: in instantiation of member function 'cmk::entry_fn_impl_<void (cmk::completion::*)(std::unique_ptr<cmk::data_message<cmk::completion::count>> &&), &cmk::completion::receive_count_>::id_' requested here
        return entry_fn_impl_<T, t>::id_();
                                     ^
../../include/proxy.hh:154:17: note: in instantiation of function template specialization 'cmk::entry<void (cmk::completion::*)(std::unique_ptr<cmk::data_message<cmk::completion::count>> &&), &cmk::completion::receive_count_>' requested here
                entry<member_fn_t<T, Message>, Fn>());
                ^
../../include/completion.hh:95:26: note: in instantiation of function template specialization 'cmk::collection_proxy_base_<cmk::completion>::callback<cmk::data_message<cmk::completion::count>, &cmk::completion::receive_count_>' requested here
                        .callback<count_message, &completion::receive_count_>();
                         ^
../../include/ep.hh:22:27: note: forward declaration of template entity is here
        static entry_id_t id_;
                          ^
../../include/ep.hh:41:55: note: add an explicit instantiation declaration to suppress this warning if 'cmk::entry_fn_helper_<&cmk::entry_fn_impl_<void (cmk::completion::*)(std::unique_ptr<cmk::data_message<cmk::completion::count>> &&), &cmk::completion::receive_count_>::call_, false>::id_' is explicitly instantiated in another translation unit
            return entry_fn_helper_<(&call_), false>::id_;
                                                      ^
In file included from ../../src/core.cc:3:
In file included from ../../include/collection.hh:4:
In file included from ../../include/collection.impl.hh:4:
In file included from ../../include/completion.hh:5:
../../include/message.hh:264:41: warning: instantiation of variable 'cmk::message_helper_<cmk::data_message<cmk::completion::count>>::kind_' required here, but no definition is available [-Wundefined-var-template]
          : message(message_helper_<T>::kind_, sizeof(T))
                                        ^
../../include/message.hh:281:9: note: in instantiation of member function 'cmk::plain_message<cmk::data_message<cmk::completion::count>>::plain_message' requested here
        data_message(Args&&... args)
        ^
../../include/common.hh:71:25: note: in instantiation of function template specialization 'cmk::data_message<cmk::completion::count>::data_message<cmk::collection_index_t &, long long &>' requested here
        auto* msg = new Message(std::forward<Args>(args)...);
                        ^
../../include/completion.hh:96:30: note: in instantiation of function template specialization 'cmk::make_message<cmk::data_message<cmk::completion::count>, cmk::collection_index_t &, long long &>' requested here
                auto count = make_message<count_message>(idx, status.lcount);
                             ^
../../include/message.hh:36:31: note: forward declaration of template entity is here
        static message_kind_t kind_;
                              ^
../../include/message.hh:264:41: note: add an explicit instantiation declaration to suppress this warning if 'cmk::message_helper_<cmk::data_message<cmk::completion::count>>::kind_' is explicitly instantiated in another translation unit
          : message(message_helper_<T>::kind_, sizeof(T))
                                        ^
In file included from ../../src/core.cc:3:
In file included from ../../include/collection.hh:4:
In file included from ../../include/collection.impl.hh:4:
In file included from ../../include/completion.hh:6:
../../include/proxy.hh:118:54: warning: instantiation of variable 'cmk::combiner_helper_<cmk::data_message<cmk::completion::count>, &cmk::add>::id_' required here, but no definition is available [-Wundefined-var-template]
                combiner_helper_<Message, Combiner>::id_);
                                                     ^
../../include/completion.hh:98:22: note: in instantiation of function template specialization 'cmk::element_proxy<cmk::completion>::contribute<cmk::data_message<cmk::completion::count>, &cmk::add>' requested here
                    .contribute<count_message,
                     ^
../../include/callback.hh:11:30: note: forward declaration of template entity is here
        static combiner_id_t id_;
                             ^
../../include/proxy.hh:118:54: note: add an explicit instantiation declaration to suppress this warning if 'cmk::combiner_helper_<cmk::data_message<cmk::completion::count>, &cmk::add>::id_' is explicitly instantiated in another translation unit
                combiner_helper_<Message, Combiner>::id_);
                                                     ^
3 warnings generated.
```

We probably need better isolation of translation units.