### PR TITLE
PE0's need not apply

### DIFF
--- a/include/charmlite/core/collection.hpp
+++ b/include/charmlite/core/collection.hpp
@@ -45,6 +45,8 @@ namespace cmk {
                     // TODO ( that said, it should be elim'd for node/groups   )
                     if (this->locmgr_.pe_for(view) == CmiMyPe())
                     {
+                        // simulate an insertion event
+                        this->produce();
                         // message should be packed
                         auto clone = msg->clone();
                         clone->dst_.endpoint().chare = view;

--- a/include/charmlite/core/collection_bridge.hpp
+++ b/include/charmlite/core/collection_bridge.hpp
@@ -332,6 +332,7 @@ namespace cmk {
 
         void register_endpoint(const facade_& f, const chare_index_t& idx)
         {
+            CmiAssert(this->endpoint_ == helper_::chare_bcast_root_);
             this->endpoint_ = idx;
             auto elt =
                 f.elt_ ? f.elt_ : this->template lookup<chare_base_>(idx);
@@ -362,17 +363,30 @@ namespace cmk {
         {
             auto mine = CmiMyPe();
             auto parent = binary_tree::parent(mine);
-            if (parent >= 0)
-            {
+
+            auto send = [&](int pe) {
                 auto src = f.elt_ == nullptr ? f.pe_ : mine;
                 auto msg = this->make_message<index_message,
                     &self_type::receive_downstream>(src, idx);
-                send_helper_(parent, std::move(msg));
+                send_helper_(pe, std::move(msg));
+            };
+
+            if (parent >= 0)
+            {
+                send(parent);
+            }
+            else if (this->endpoint_ == helper_::chare_bcast_root_)
+            {
+                // set the element as the endpoint if it
+                // hasn't been set before
+                this->register_endpoint(f, idx);
             }
             else
             {
-                this->register_endpoint(f, idx);
+                // TODO ( this is a fascimile of send_downstream )
+                send((this->locmgr_).pe_for(this->endpoint_));
             }
+
             this->produce();
         }
 

--- a/include/charmlite/core/collection_bridge.hpp
+++ b/include/charmlite/core/collection_bridge.hpp
@@ -130,6 +130,8 @@ namespace cmk {
             return false;
         }
 
+        void produce(void) {}
+
         void set_insertion_status(bool, std::nullptr_t) {}
 
         const chare_index_t* root(void) const
@@ -166,6 +168,14 @@ namespace cmk {
           : collection_base_(id)
           , endpoint_(cmk::helper_::chare_bcast_root_)
         {
+        }
+
+        void produce(std::int64_t count = 1)
+        {
+            if (count != 0)
+            {
+                system_detector_()->produce(this->id_, count);
+            }
         }
 
         bool is_inserting(void) const
@@ -280,14 +290,6 @@ namespace cmk {
                 destination(this->id_, cmk::helper_::chare_bcast_root_, entry);
             msg->for_collection() = true;
             return msg;
-        }
-
-        void produce(std::int64_t count = 1)
-        {
-            if (count != 0)
-            {
-                system_detector_()->produce(this->id_, count);
-            }
         }
 
         void consume(void)
@@ -467,6 +469,8 @@ namespace cmk {
                 {
                     assoc->put_parent(target->index_);
                 }
+                // confirm the element's been created
+                this->consume();
             }
             else
             {

--- a/include/charmlite/core/impl/proxy.hpp
+++ b/include/charmlite/core/impl/proxy.hpp
@@ -16,6 +16,7 @@ namespace cmk {
             message_extractor<arg_type>::get(std::forward<Args>(args)...);
         new (&(msg->dst_))
             destination(this->id_, this->idx_, constructor<T, arg_type>());
+        cmk::system_detector_()->produce(this->id_, 1);
         cmk::send(std::move(msg));
     }
 


### PR DESCRIPTION
- Adds support for scenarios when PE0 has no elements, by:
- Routing "upstreaming" request "downstream" to a known endpoint.
- Ensures "endpoint" has not been set multiple times.
- Adds insertion events to QD for tree-building (ensure all inserts considered).