### PR TITLE
Update CharmLite to use C++17 by default

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -8,12 +8,6 @@ if(CMAKE_VERSION VERSION_GREATER 3.22.1 OR CMAKE_VERSION VERSION_EQUAL 3.22.1)
     cmake_policy(SET CMP0115 OLD)
 endif()
 
-# Make sure all executables go in bin directory and all libraries go in lib
-# directory.
-set(CMAKE_LIBRARY_OUTPUT_DIRECTORY "${PROJECT_BINARY_DIR}/lib")
-set(CMAKE_ARCHIVE_OUTPUT_DIRECTORY "${PROJECT_BINARY_DIR}/lib")
-set(CMAKE_RUNTIME_OUTPUT_DIRECTORY "${PROJECT_BINARY_DIR}/bin")
-
 # Make Default Build Type Release
 if(NOT CMAKE_BUILD_TYPE)
     set(CMAKE_BUILD_TYPE
@@ -30,8 +24,15 @@ message(STATUS "Found Charm++ at ${CHARM_ROOT}")
 message(STATUS "Switching to Charm CXX Compiler: ${CHARM_ROOT}/bin/charmc")
 
 set(CMAKE_CXX_COMPILER ${CHARM_CXX_COMPILER})
+
 # Make sure correct compiler is set before starting the project
 project(CharmLite CXX)
+
+# Make sure all executables go in bin directory and all libraries go in lib
+# directory.
+set(CMAKE_LIBRARY_OUTPUT_DIRECTORY "${PROJECT_BINARY_DIR}/lib")
+set(CMAKE_ARCHIVE_OUTPUT_DIRECTORY "${PROJECT_BINARY_DIR}/lib")
+set(CMAKE_RUNTIME_OUTPUT_DIRECTORY "${PROJECT_BINARY_DIR}/bin")
 
 set(CMAKE_CXX_FLAGS "-language converse++ -Wall -Wextra" CACHE STRING "Additional arguments to charmc" FORCE)
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -8,8 +8,6 @@ if(CMAKE_VERSION VERSION_GREATER 3.22.1 OR CMAKE_VERSION VERSION_EQUAL 3.22.1)
     cmake_policy(SET CMP0115 OLD)
 endif()
 
-project(CharmLite CXX)
-
 # Make sure all executables go in bin directory and all libraries go in lib
 # directory.
 set(CMAKE_LIBRARY_OUTPUT_DIRECTORY "${PROJECT_BINARY_DIR}/lib")
@@ -32,14 +30,24 @@ message(STATUS "Found Charm++ at ${CHARM_ROOT}")
 message(STATUS "Switching to Charm CXX Compiler: ${CHARM_ROOT}/bin/charmc")
 
 set(CMAKE_CXX_COMPILER ${CHARM_CXX_COMPILER})
+# Make sure correct compiler is set before starting the project
+project(CharmLite CXX)
+
 set(CMAKE_CXX_FLAGS "-language converse++ -Wall -Wextra" CACHE STRING "Additional arguments to charmc" FORCE)
 
 # Charmlite requires a conforming C++11 compiler
-set(CMAKE_CXX_STANDARD ${CHARM_CXX_STANDARD})
+set(CMAKE_CXX_STANDARD 17)
 set(CMAKE_CXX_STANDARD_REQUIRED True)
+
+# charmc currently appends -std=c++11 so we need to explicitly pass the
+# option again
+add_compile_options(-cpp-option -std=c++17)
 
 # Add cmake to module path
 list(APPEND CMAKE_MODULE_PATH "${PROJECT_SOURCE_DIR}/cmake")
+
+# Ensure required facilities work
+include(CharmLite_TestCXXFeatures)
 
 # Include the testing framework
 include(CharmLite_SetupTests)

--- a/cmake/CharmLite_TestCXXFeatures.cmake
+++ b/cmake/CharmLite_TestCXXFeatures.cmake
@@ -1,0 +1,22 @@
+set(CHARMLITE_INTERNAL_CXX_TESTS ${CMAKE_SOURCE_DIR}/cmake/tests)
+
+set(INTERNAL_TESTS
+    ctad
+    template_auto
+)
+
+message(STATUS "Testing C++17 compliance")
+foreach(INTERNAL_TEST ${INTERNAL_TESTS})
+    set(INTERNAL_TEST_NAME ${INTERNAL_TEST}.cpp)
+    try_compile(
+        RESULT_VAR
+        ${CMAKE_BINARY_DIR}/internal_tests
+        ${CHARMLITE_INTERNAL_CXX_TESTS}/${INTERNAL_TEST_NAME}
+        COMPILE_DEFINITIONS "-c++-option -std=c++17"
+        OUTPUT_VARIABLE TRY_COMPILE_OUTPUT)
+    
+    if(${RESULT_VAR} STREQUAL "FALSE")
+        message(STATUS "${RESULT_VAR} ${TRY_COMPILE_OUTPUT}")
+        message(FATAL_ERROR "CharmLite requires C++17 compliant compiler.")
+    endif()
+endforeach()

--- a/cmake/tests/ctad.cpp
+++ b/cmake/tests/ctad.cpp
@@ -1,0 +1,6 @@
+#include <vector>
+
+int main(int argc, char* argv[])
+{
+    std::vector vec{1, 2, 3, 4};
+}

--- a/cmake/tests/template_auto.cpp
+++ b/cmake/tests/template_auto.cpp
@@ -1,0 +1,10 @@
+template <auto Val>
+void do_nohing()
+{
+}
+
+int main(int argc, char* argv[])
+{
+    do_nohing<42>();
+    do_nohing<'a'>();
+}

--- a/examples/basic/pgm.cpp
+++ b/examples/basic/pgm.cpp
@@ -51,9 +51,12 @@ int main(int argc, char** argv)
         auto n = 8 * nPes;
         for (auto i = 0; i < n; i++)
         {
-            if ((i % nPes == 0) && (nPes != 1)) {
+            if ((i % nPes == 0) && (nPes != 1))
+            {
                 n++;
-            } else {
+            }
+            else
+            {
                 arr[i].insert(cmk::make_message<test_message>(i));
             }
         }

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -6,5 +6,4 @@ set(LIB_FILES
 
 add_library(charmlite STATIC ${LIB_FILES})
 target_include_directories(charmlite
-    PUBLIC $<BUILD_INTERFACE:${PROJECT_SOURCE_DIR}/include>
-    $<INSTALL_INTERFACE:include>)
+    PUBLIC $<BUILD_INTERFACE:${PROJECT_SOURCE_DIR}/include>)


### PR DESCRIPTION
This PR switches charmlite to use C++17. Furthermore, it tests 2 necessary features utilized in charmlite that have been standardized in C++17, i.e. CTAD and `template <auto F> ...`.