### PR TITLE
Port ep.hpp to C++17 if constexpr solution

### DIFF
--- a/include/charmlite/core/ep.hpp
+++ b/include/charmlite/core/ep.hpp
@@ -46,25 +46,25 @@ namespace cmk {
         }
     };
 
-    template <typename A, typename MessagePtr>
+    template <typename Chare, typename Argument>
     struct constructor_caller_
     {
         auto operator()(void* self, message_ptr<>&& msg)
         {
-            if constexpr (cmk::message_compatibility_v<MessagePtr>)
+            if constexpr (cmk::message_compatibility_v<Argument>)
             {
-                using Message = cmk::get_message_t<MessagePtr>;
+                using Message = cmk::get_message_t<Argument>;
                 auto* typed = static_cast<Message*>(msg.release());
                 message_ptr<Message> owned(typed);
-                new (static_cast<A*>(self)) A(std::move(owned));
+                new (static_cast<Chare*>(self)) Chare(std::move(owned));
             }
-            else if constexpr (std::is_same_v<MessagePtr, void>)
+            else if constexpr (std::is_same_v<Argument, void>)
             {
-                new (static_cast<A*>(self)) A;
+                new (static_cast<Chare*>(self)) Chare;
             }
             else
             {
-                assert(false &&
+                CmiEnforceMsg(false &&
                     "constructor_caller_ called with a message pointer of "
                     "non-message type");
             }

--- a/include/charmlite/core/ep.hpp
+++ b/include/charmlite/core/ep.hpp
@@ -62,7 +62,7 @@ namespace cmk {
             }
             else
             {
-                CmiEnforceMsg(false &&
+                CmiAbort(
                     "constructor_caller_ called with a message pointer of "
                     "non-message type");
             }

--- a/include/charmlite/core/ep.hpp
+++ b/include/charmlite/core/ep.hpp
@@ -5,8 +5,6 @@
 
 #include <charmlite/utilities/traits.hpp>
 
-#include <cassert>
-
 namespace cmk {
     inline const entry_record_* record_for(entry_id_t id)
     {

--- a/include/charmlite/utilities/traits/message.hpp
+++ b/include/charmlite/utilities/traits/message.hpp
@@ -118,6 +118,37 @@ namespace cmk {
     template <typename T>
     using is_message_t = typename is_message<T>::type;
 
+    template <typename T>
+    inline constexpr bool is_message_v = is_message<T>::value;
+
+    template <typename T>
+    struct message_compatibility
+    {
+        static constexpr bool value = false;
+    };
+
+    template <typename Message>
+    struct message_compatibility<message_ptr<Message>&&>
+    {
+        static constexpr bool value = true;
+    };
+
+    template <typename T>
+    inline constexpr bool message_compatibility_v =
+        message_compatibility<T>::value;
+
+    template <typename T>
+    struct get_message;
+
+    template <typename T>
+    struct get_message<message_ptr<T>&&>
+    {
+        using type = T;
+    };
+
+    template <typename T>
+    using get_message_t = typename get_message<T>::type;
+
 }    // namespace cmk
 
 #endif


### PR DESCRIPTION
This PR ports `constructor_call_` to `if constexpr` solution. It also adds additional traits that will be useful in getting underlying types.

TODO: Port `entry_fn_*` routines to `template <auto ...>` (in the 2nd pass)