### PR TITLE
Uplift user facing APIs to template <auto>

### DIFF
--- a/benchmarks/cbench/pgm.cpp
+++ b/benchmarks/cbench/pgm.cpp
@@ -34,16 +34,14 @@ struct communicator : public cmk::chare<communicator, int>
         }
         else if ((it % nChares) == this->index())
         {
-            this->collection_proxy()
-                .broadcast<cmk::message, &communicator::recv_broadcast>(
-                    std::move(msg));
+            this->collection_proxy().broadcast<&communicator::recv_broadcast>(
+                std::move(msg));
         }
     }
 
     void recv_broadcast(cmk::message_ptr<>&& msg)
     {
-        auto cb = this->collection_proxy()
-                      .callback<cmk::message, &communicator::run>();
+        auto cb = this->collection_proxy().callback<&communicator::run>();
         this->element_proxy().contribute<cmk::message, cmk::nop>(
             std::move(msg), cb);
     }
@@ -92,7 +90,7 @@ int main(int argc, char** argv)
 
             auto startTime = CmiWallTimer();
 
-            arr.broadcast<cmk::message, &communicator::run>(
+            arr.broadcast<&communicator::run>(
                 cmk::make_message<cmk::message>());
             CthSuspend();
 

--- a/benchmarks/cbench/pgm.cpp
+++ b/benchmarks/cbench/pgm.cpp
@@ -29,7 +29,7 @@ struct communicator : public cmk::chare<communicator, int>
             it = 0;
 
             auto cb = cmk::callback<cmk::message>::construct<resume_main>(0);
-            this->element_proxy().contribute<cmk::message, cmk::nop>(
+            this->element_proxy().contribute<cmk::nop<cmk::message>>(
                 std::move(msg), cb);
         }
         else if ((it % nChares) == this->index())
@@ -42,7 +42,7 @@ struct communicator : public cmk::chare<communicator, int>
     void recv_broadcast(cmk::message_ptr<>&& msg)
     {
         auto cb = this->collection_proxy().callback<&communicator::run>();
-        this->element_proxy().contribute<cmk::message, cmk::nop>(
+        this->element_proxy().contribute<cmk::nop<cmk::message>>(
             std::move(msg), cb);
     }
 };

--- a/benchmarks/pingpong/pgm.cpp
+++ b/benchmarks/pingpong/pgm.cpp
@@ -64,8 +64,7 @@ struct pingpong : public cmk::chare<pingpong, int>
         cmk::message::free(msg);
         // then GO!
         this->startTime = CmiWallTimer();
-        peer.send<payload_message, &pingpong::receive_message>(
-            std::move(payload));
+        peer.send<&pingpong::receive_message>(std::move(payload));
     }
 
     void receive_message(cmk::message_ptr<payload_message>&& msg)
@@ -80,8 +79,7 @@ struct pingpong : public cmk::chare<pingpong, int>
         }
         else
         {
-            peer.send<payload_message, &pingpong::receive_message>(
-                std::move(msg));
+            peer.send<&pingpong::receive_message>(std::move(msg));
         }
     }
 };
@@ -113,10 +111,10 @@ int main(int argc, char** argv)
         // allocate the launch pack
         auto msg = cmk::make_message<run_message_t>(sz, nIts);
         // then run through a warm up phase
-        grp[0].send<run_message_t, &pingpong::run>(msg->clone<run_message_t>());
+        grp[0].send<&pingpong::run>(msg->clone<run_message_t>());
         CthSuspend();
         // then run through the measurement phase
-        grp[0].send<run_message_t, &pingpong::run>(std::move(msg));
+        grp[0].send<&pingpong::run>(std::move(msg));
         CthSuspend();
         // print the final round-trip time
         CmiPrintf("main> roundtrip time was %g us\n",

--- a/examples/basic/pgm.cpp
+++ b/examples/basic/pgm.cpp
@@ -34,7 +34,7 @@ struct foo : public cmk::chare<foo, int>
             msg->val, this->val + msg->val);
         auto cb =
             cmk::callback<cmk::message>::construct<cmk::exit>(cmk::all::pes);
-        this->element_proxy().contribute<cmk::message, cmk::nop>(
+        this->element_proxy().contribute<cmk::nop<cmk::message>>(
             std::move(msg), cb);
     }
 };

--- a/examples/basic/pgm.cpp
+++ b/examples/basic/pgm.cpp
@@ -61,8 +61,7 @@ int main(int argc, char** argv)
             }
         }
         // then send 'em a buncha' messages
-        arr.broadcast<test_message, &foo::bar>(
-            cmk::make_message<test_message>(n));
+        arr.broadcast<&foo::bar>(cmk::make_message<test_message>(n));
         // necessary to enable collective communication
         arr.done_inserting();
     }

--- a/examples/cdt/pgm.cpp
+++ b/examples/cdt/pgm.cpp
@@ -44,7 +44,7 @@ struct test : cmk::chare<test, int>
             local->produce(this->collection(), CmiNumPes());
             // so send the messages
             cmk::group_proxy<test> col(this->collection());
-            col.broadcast<cmk::message, &test::consume>(std::move(msg));
+            col.broadcast<&test::consume>(std::move(msg));
         }
     }
 
@@ -73,8 +73,8 @@ struct test : cmk::chare<test, int>
                     this->collection(), cb);
                 // (each pe could start its own completion detection
                 //  but this checks that broadcasts are working!)
-                detector.broadcast<cmk::completion::detection_message,
-                    &cmk::completion::start_detection>(std::move(dm));
+                detector.broadcast<&cmk::completion::start_detection>(
+                    std::move(dm));
 
                 detection_started_ = true;
             }
@@ -106,8 +106,7 @@ int main(int argc, char** argv)
         for (auto it = 0; it < nIts; it++)
         {
             // send each element a "produce" message to start the process
-            elts.broadcast<cmk::message, &test::produce>(
-                cmk::make_message<cmk::message>());
+            elts.broadcast<&test::produce>(cmk::make_message<cmk::message>());
             // sleep until detection completes
             CthSuspend();
             CmiPrintf("main> iteration %d complete!\n", it + 1);

--- a/examples/cdt/pgm.cpp
+++ b/examples/cdt/pgm.cpp
@@ -35,7 +35,7 @@ struct test : cmk::chare<test, int>
         {
             auto elt = this->element_proxy();
             // put the message back to if we don't
-            elt.send<cmk::message, &test::produce>(std::move(msg));
+            elt.send<&test::produce>(std::move(msg));
         }
         else
         {
@@ -55,7 +55,7 @@ struct test : cmk::chare<test, int>
         {
             auto elt = this->element_proxy();
             // put the message back to await local branch creation
-            elt.send<cmk::message, &test::consume>(std::move(msg));
+            elt.send<&test::consume>(std::move(msg));
         }
         else
         {

--- a/examples/jacobi/jacobi.cpp
+++ b/examples/jacobi/jacobi.cpp
@@ -187,7 +187,7 @@ public:
                 ghost_data[j] = temperature[1][j + 1];
             this_proxy[std::tuple<int, int>(std::get<0>(this_index) - 1,
                            std::get<1>(this_index))]
-                .send<ghost_message, &jacobi::receive_ghosts>(std::move(msg));
+                .send<&jacobi::receive_ghosts>(std::move(msg));
         }
         if (!right_bound)
         {
@@ -198,7 +198,7 @@ public:
                 ghost_data[j] = temperature[block_dim_x][j + 1];
             this_proxy[std::tuple<int, int>(std::get<0>(this_index) + 1,
                            std::get<1>(this_index))]
-                .send<ghost_message, &jacobi::receive_ghosts>(std::move(msg));
+                .send<&jacobi::receive_ghosts>(std::move(msg));
         }
         if (!top_bound)
         {
@@ -209,7 +209,7 @@ public:
                 ghost_data[i] = temperature[i + 1][1];
             this_proxy[std::tuple<int, int>(std::get<0>(this_index),
                            std::get<1>(this_index) - 1)]
-                .send<ghost_message, &jacobi::receive_ghosts>(std::move(msg));
+                .send<&jacobi::receive_ghosts>(std::move(msg));
         }
         if (!bottom_bound)
         {
@@ -220,7 +220,7 @@ public:
                 ghost_data[i] = temperature[i + 1][block_dim_y];
             this_proxy[std::tuple<int, int>(std::get<0>(this_index),
                            std::get<1>(this_index) + 1)]
-                .send<ghost_message, &jacobi::receive_ghosts>(std::move(msg));
+                .send<&jacobi::receive_ghosts>(std::move(msg));
         }
     }
 
@@ -295,8 +295,7 @@ public:
 
         auto cb = this_proxy.callback<&jacobi::check_completion>();
         this->element_proxy()
-            .contribute<completion_message,
-                cmk::logical_and<typename completion_message::type>>(
+            .contribute<cmk::logical_and<typename completion_message::type>>(
                 std::move(msg), cb);
     }
 

--- a/examples/jacobi/jacobi.cpp
+++ b/examples/jacobi/jacobi.cpp
@@ -293,9 +293,7 @@ public:
         bool converged = (max_error <= THRESHOLD);
         auto msg = cmk::make_message<completion_message>(converged);
 
-        auto cb =
-            this_proxy
-                .callback<completion_message, &jacobi::check_completion>();
+        auto cb = this_proxy.callback<&jacobi::check_completion>();
         this->element_proxy()
             .contribute<completion_message,
                 cmk::logical_and<typename completion_message::type>>(

--- a/include/charmlite/core/chare.hpp
+++ b/include/charmlite/core/chare.hpp
@@ -50,11 +50,8 @@ namespace cmk {
         return CMK_ACCESS_SINGLETON(chare_table_)[id - 1];
     }
 
-    template <typename T, typename Enable = void>
-    struct property_setter_
-    {
-        void operator()(T*, const collection_index_t&, const chare_index_t&) {}
-    };
+    template <typename T>
+    struct property_setter_;
 
     template <typename T, typename Index>
     class chare;
@@ -133,19 +130,21 @@ namespace cmk {
         template <typename T, template <class> class Mapper, typename Enable>
         friend class collection_bridge_;
 
-        template <typename T, typename Enable>
+        template <typename T>
         friend struct property_setter_;
     };
 
     template <typename T>
-    struct property_setter_<T,
-        typename std::enable_if<std::is_base_of<chare_base_, T>::value>::type>
+    struct property_setter_
     {
         void operator()(
             T* t, const collection_index_t& id, const chare_index_t& idx)
         {
-            t->parent_ = id;
-            t->index_ = idx;
+            if constexpr (std::is_base_of<chare_base_, T>::value)
+            {
+                t->parent_ = id;
+                t->index_ = idx;
+            }
         }
     };
 

--- a/include/charmlite/core/completion.hpp
+++ b/include/charmlite/core/completion.hpp
@@ -91,9 +91,8 @@ namespace cmk {
             else
             {
                 // contribute to the all_reduce with other participants
-                auto cb =
-                    this->collection_proxy()
-                        .callback<count_message, &completion::receive_count_>();
+                auto cb = this->collection_proxy()
+                              .callback<&completion::receive_count_>();
                 auto count = make_message<count_message>(idx, status.lcount);
                 this->element_proxy()
                     .contribute<count_message,

--- a/include/charmlite/core/completion.hpp
+++ b/include/charmlite/core/completion.hpp
@@ -95,8 +95,7 @@ namespace cmk {
                               .callback<&completion::receive_count_>();
                 auto count = make_message<count_message>(idx, status.lcount);
                 this->element_proxy()
-                    .contribute<count_message,
-                        add<typename count_message::type>>(
+                    .contribute<&cmk::add<typename count_message::type>>(
                         std::move(count), cb);
             }
         }

--- a/include/charmlite/core/core.hpp
+++ b/include/charmlite/core/core.hpp
@@ -9,6 +9,7 @@
 #include <charmlite/core/completion.hpp>
 #include <charmlite/core/destination.hpp>
 #include <charmlite/core/ep.hpp>
+#include <charmlite/core/indexing.hpp>
 #include <charmlite/core/locmgr.hpp>
 #include <charmlite/core/message.hpp>
 #include <charmlite/core/options.hpp>

--- a/include/charmlite/core/proxy.hpp
+++ b/include/charmlite/core/proxy.hpp
@@ -119,21 +119,24 @@ namespace cmk {
             return element_proxy<T>(this->id_, view);
         }
 
-        template <typename Message, member_fn_t<T, Message> Fn>
-        cmk::callback<Message> callback(void) const
+        // template <typename Message, member_fn_t<T, Message> Fn>
+        template <auto Fn>
+        auto callback(void) const
         {
-            return cmk::callback<Message>(this->id_,
-                cmk::helper_::chare_bcast_root_,
-                entry<member_fn_t<T, Message>, Fn>());
+            using message_t = typename cmk::extract_message<decltype(Fn)>::type;
+
+            return cmk::callback<message_t>(this->id_,
+                cmk::helper_::chare_bcast_root_, entry<decltype(Fn), Fn>());
         }
 
-        template <typename Message, member_fn_t<T, Message> Fn>
-        void broadcast(message_ptr<Message>&& msg) const
+        // template <typename Message, member_fn_t<T, Message> Fn>
+        template <auto Fn>
+        void broadcast(
+            typename cmk::extract_message<decltype(Fn)>::ptr_type&& msg) const
         {
             // send a message to the broadcast root
-            new (&msg->dst_)
-                destination(this->id_, cmk::helper_::chare_bcast_root_,
-                    entry<member_fn_t<T, Message>, Fn>());
+            new (&msg->dst_) destination(this->id_,
+                cmk::helper_::chare_bcast_root_, entry<decltype(Fn), Fn>());
             cmk::send(std::move(msg));
         }
 

--- a/include/charmlite/core/proxy.hpp
+++ b/include/charmlite/core/proxy.hpp
@@ -7,6 +7,8 @@
 #include <charmlite/core/ep.hpp>
 #include <charmlite/core/locmgr.hpp>
 
+#include <charmlite/utilities/traits.hpp>
+
 namespace cmk {
 
     template <typename T, typename Enable = void>
@@ -87,16 +89,23 @@ namespace cmk {
 
         void insert(int pe = -1) const;
 
-        template <typename Message, member_fn_t<T, Message> Fn>
-        void send(message_ptr<Message>&& msg) const;
+        // template <typename Message, member_fn_t<T, Message> Fn>
+        template <auto Fn>
+        void send(
+            typename cmk::extract_message<decltype(Fn)>::ptr_type&& msg) const;
 
-        template <typename Message, member_fn_t<T, Message> Fn>
-        cmk::callback<Message> callback(void) const;
+        // template <typename Message, member_fn_t<T, Message> Fn>
+        template <auto Fn>
+        auto callback(void) const;
 
     protected:
-        template <typename Message, combiner_fn_t<Message> Combiner>
+        // template <typename Message, combiner_fn_t<Message> Combiner>
+        template <auto Combiner>
         void contribute(
-            message_ptr<Message>&& msg, const cmk::callback<Message>& cb) const;
+            typename cmk::extract_message<decltype(Combiner)>::ptr_type&& msg,
+            const cmk::callback<
+                typename cmk::extract_message<decltype(Combiner)>::type>& cb)
+            const;
     };
 
     template <typename T>

--- a/include/charmlite/utilities/traits.hpp
+++ b/include/charmlite/utilities/traits.hpp
@@ -20,6 +20,16 @@ namespace cmk {
     template <typename T>
     using viable_argument_t = typename viable_argument<T>::type;
 
+    template <typename T>
+    struct extract_message;
+
+    template <typename T, typename Message>
+    struct extract_message<member_fn_t<T, Message>>
+    {
+        using type = Message;
+        using ptr_type = message_ptr<Message>;
+    };
+
 }    // namespace cmk
 
 #endif

--- a/include/charmlite/utilities/traits.hpp
+++ b/include/charmlite/utilities/traits.hpp
@@ -30,6 +30,13 @@ namespace cmk {
         using ptr_type = message_ptr<Message>;
     };
 
+    template <typename Message>
+    struct extract_message<combiner_fn_t<Message>>
+    {
+        using type = Message;
+        using ptr_type = message_ptr<Message>;
+    };
+
 }    // namespace cmk
 
 #endif

--- a/tests/indexing/compile_time.cpp
+++ b/tests/indexing/compile_time.cpp
@@ -1,19 +1,27 @@
-#include <charmlite/core/indexing.hpp>
+#include <charmlite/charmlite.hpp>
 
 #include <tuple>
 
-int main()
+int main(int argc, char* argv[])
 {
-    // 1D range
-    constexpr cmk::index_range<int> index_range_1d{0, 1, 5};
-    constexpr int next_1d = index_range_1d.next(0);
-    static_assert(next_1d == 1, "Next computed incorrectly for 1D range!");
+    cmk::initialize(argc, argv);
 
-    constexpr cmk::index_range<std::tuple<int, int>> index_range_2d{
-        std::tuple<int, int>{0, 0}, std::tuple<int, int>{0, 1},
-        std::tuple<int, int>{2, 2}};
-    constexpr std::tuple<int, int> next_2d =
-        index_range_2d.next(std::make_tuple(0, 0));
-    static_assert(std::get<0>(next_2d) == 0 && std::get<1>(next_2d) == 0,
-        "Next computed incorrectly for 2D range!");
+    if (CmiMyNode() == 0)
+    {
+        // 1D range
+        constexpr cmk::index_range<int> index_range_1d{0, 1, 5};
+        constexpr int next_1d = index_range_1d.next(0);
+        static_assert(next_1d == 1, "Next computed incorrectly for 1D range!");
+
+        constexpr cmk::index_range<std::tuple<int, int>> index_range_2d{
+            std::tuple<int, int>{0, 0}, std::tuple<int, int>{0, 1},
+            std::tuple<int, int>{2, 2}};
+        constexpr std::tuple<int, int> next_2d =
+            index_range_2d.next(std::make_tuple(0, 0));
+        static_assert(std::get<0>(next_2d) == 0 && std::get<1>(next_2d) == 0,
+            "Next computed incorrectly for 2D range!");
+    }
+
+    cmk::finalize();
+    return 0;
 }


### PR DESCRIPTION
This PR uplifts various user-facing APIs such as broadcast, contribute, send, and callbacks to `template <auto>`. This change leads to one less template argument which improves the overall readability of user code.

Random Flyby:
 - Update `property_setter_` to `if constexpr`