### PR TITLE
Allow CI to run the tests added to Charmlite

### DIFF
--- a/.github/workflows/clang_non_smp.yml
+++ b/.github/workflows/clang_non_smp.yml
@@ -38,7 +38,7 @@ jobs:
       run: |
         mkdir build
         cd build
-        cmake -DCHARMLITE_ENABLE_BENCHMARKS=ON -DCMAKE_PREFIX_PATH=$GITHUB_WORKSPACE/charm ..
+        cmake -DCHARMLITE_ENABLE_BENCHMARKS=ON -DCHARMLITE_ENABLE_TESTS=ON -DCMAKE_PREFIX_PATH=$GITHUB_WORKSPACE/charm ..
         make -j2
 
     # Test CharmLite

--- a/.github/workflows/clang_smp.yml
+++ b/.github/workflows/clang_smp.yml
@@ -38,7 +38,7 @@ jobs:
       run: |
         mkdir build
         cd build
-        cmake -DCHARMLITE_ENABLE_BENCHMARKS=ON -DCMAKE_PREFIX_PATH=$GITHUB_WORKSPACE/charm ..
+        cmake -DCHARMLITE_ENABLE_BENCHMARKS=ON -DCHARMLITE_ENABLE_TESTS=ON -DCMAKE_PREFIX_PATH=$GITHUB_WORKSPACE/charm ..
         make -j2
 
     # Test CharmLite

--- a/.github/workflows/gcc_non_smp.yml
+++ b/.github/workflows/gcc_non_smp.yml
@@ -38,7 +38,7 @@ jobs:
       run: |
         mkdir build
         cd build
-        cmake -DCHARMLITE_ENABLE_BENCHMARKS=ON -DCMAKE_PREFIX_PATH=$GITHUB_WORKSPACE/charm ..
+        cmake -DCHARMLITE_ENABLE_BENCHMARKS=ON -DCHARMLITE_ENABLE_TESTS=ON -DCMAKE_PREFIX_PATH=$GITHUB_WORKSPACE/charm ..
         make -j2
 
     # Test CharmLite

--- a/.github/workflows/gcc_smp.yml
+++ b/.github/workflows/gcc_smp.yml
@@ -38,7 +38,7 @@ jobs:
       run: |
         mkdir build
         cd build
-        cmake -DCHARMLITE_ENABLE_BENCHMARKS=ON -DCMAKE_PREFIX_PATH=$GITHUB_WORKSPACE/charm ..
+        cmake -DCHARMLITE_ENABLE_BENCHMARKS=ON -DCHARMLITE_ENABLE_TESTS=ON -DCMAKE_PREFIX_PATH=$GITHUB_WORKSPACE/charm ..
         make -j2
 
     # Test CharmLite

--- a/tests/indexing/compile_time.cpp
+++ b/tests/indexing/compile_time.cpp
@@ -20,6 +20,8 @@ int main(int argc, char* argv[])
             index_range_2d.next(std::make_tuple(0, 0));
         static_assert(std::get<0>(next_2d) == 0 && std::get<1>(next_2d) == 0,
             "Next computed incorrectly for 2D range!");
+
+        cmk::exit();
     }
 
     cmk::finalize();


### PR DESCRIPTION
This PR adds support for running tests Charmlite CI. Currently, we only have one test that checks compile-time results for indexing but we can add more as we progress.