### PR TITLE
Uplift entry_fn_* to template <auto>

### DIFF
--- a/include/charmlite/core/collection_bridge.hpp
+++ b/include/charmlite/core/collection_bridge.hpp
@@ -161,14 +161,15 @@ namespace cmk {
         static entry_id_t receive_status(void)
         {
             using receiver_type = member_fn_t<self_type, data_message<bool>>;
-            return cmk::entry<receiver_type, &self_type::receive_status>();
+            return cmk::entry<static_cast<receiver_type>(
+                &self_type::receive_status)>();
         }
 
         static entry_id_t receive_location_update(void)
         {
             using receiver_type = member_fn_t<self_type, location_message>;
-            return cmk::entry<receiver_type,
-                &self_type::receive_location_update>();
+            return cmk::entry<static_cast<receiver_type>(
+                &self_type::receive_location_update)>();
         }
 
     protected:
@@ -307,7 +308,7 @@ namespace cmk {
         cmk::message_ptr<Message> make_message(Args&&... args)
         {
             auto msg = cmk::make_message<Message>(std::forward<Args>(args)...);
-            auto entry = cmk::entry<member_fn_t<self_type, Message>, Fn>();
+            auto entry = cmk::entry<Fn>();
             new (&(msg->dst_))
                 destination(this->id_, cmk::helper_::chare_bcast_root_, entry);
             msg->for_collection() = true;

--- a/include/charmlite/core/ep.hpp
+++ b/include/charmlite/core/ep.hpp
@@ -24,15 +24,11 @@ namespace cmk {
         static entry_id_t id_;
     };
 
-    // template <typename T>
-    // struct get_type;
-
     template <auto Fn>
     struct entry_fn_impl_
     {
         static void call_(void* self, message_ptr<>&& msg)
         {
-            // using type = typename get_type<decltype(Fn)>::type;
             if constexpr (cmk::is_member_fn_t<decltype(Fn)>::value &&
                 cmk::is_message<
                     typename cmk::extract_message<decltype(Fn)>::type>::value)
@@ -53,26 +49,6 @@ namespace cmk {
             return entry_fn_helper_<(&call_), false>::id_;
         }
     };
-
-    // template <typename T, T t, typename Enable = void>
-    // struct entry_fn_impl_;
-
-    // template <typename T, typename Message, member_fn_t<T, Message> Fn>
-    // struct entry_fn_impl_<member_fn_t<T, Message>, Fn,
-    //     typename std::enable_if<is_message<Message>::value>::type>
-    // {
-    //     static void call_(void* self, message_ptr<>&& msg)
-    //     {
-    //         auto* typed = static_cast<Message*>(msg.release());
-    //         message_ptr<Message> owned(typed);
-    //         (static_cast<T*>(self)->*Fn)(std::move(owned));
-    //     }
-
-    //     static const entry_id_t& id_(void)
-    //     {
-    //         return entry_fn_helper_<(&call_), false>::id_;
-    //     }
-    // };
 
     template <typename Chare, typename Argument>
     struct constructor_caller_

--- a/include/charmlite/core/ep.hpp
+++ b/include/charmlite/core/ep.hpp
@@ -24,18 +24,28 @@ namespace cmk {
         static entry_id_t id_;
     };
 
-    template <typename T, T t, typename Enable = void>
-    struct entry_fn_impl_;
+    // template <typename T>
+    // struct get_type;
 
-    template <typename T, typename Message, member_fn_t<T, Message> Fn>
-    struct entry_fn_impl_<member_fn_t<T, Message>, Fn,
-        typename std::enable_if<is_message<Message>::value>::type>
+    template <auto Fn>
+    struct entry_fn_impl_
     {
         static void call_(void* self, message_ptr<>&& msg)
         {
-            auto* typed = static_cast<Message*>(msg.release());
-            message_ptr<Message> owned(typed);
-            (static_cast<T*>(self)->*Fn)(std::move(owned));
+            // using type = typename get_type<decltype(Fn)>::type;
+            if constexpr (cmk::is_member_fn_t<decltype(Fn)>::value &&
+                cmk::is_message<
+                    typename cmk::extract_message<decltype(Fn)>::type>::value)
+            {
+                using message_t =
+                    typename cmk::extract_message<decltype(Fn)>::type;
+                using template_t =
+                    typename cmk::extract_message<decltype(Fn)>::template_t;
+
+                auto* typed = static_cast<message_t*>(msg.release());
+                message_ptr<message_t> owned(typed);
+                (static_cast<template_t*>(self)->*Fn)(std::move(owned));
+            }
         }
 
         static const entry_id_t& id_(void)
@@ -43,6 +53,26 @@ namespace cmk {
             return entry_fn_helper_<(&call_), false>::id_;
         }
     };
+
+    // template <typename T, T t, typename Enable = void>
+    // struct entry_fn_impl_;
+
+    // template <typename T, typename Message, member_fn_t<T, Message> Fn>
+    // struct entry_fn_impl_<member_fn_t<T, Message>, Fn,
+    //     typename std::enable_if<is_message<Message>::value>::type>
+    // {
+    //     static void call_(void* self, message_ptr<>&& msg)
+    //     {
+    //         auto* typed = static_cast<Message*>(msg.release());
+    //         message_ptr<Message> owned(typed);
+    //         (static_cast<T*>(self)->*Fn)(std::move(owned));
+    //     }
+
+    //     static const entry_id_t& id_(void)
+    //     {
+    //         return entry_fn_helper_<(&call_), false>::id_;
+    //     }
+    // };
 
     template <typename Chare, typename Argument>
     struct constructor_caller_
@@ -62,9 +92,8 @@ namespace cmk {
             }
             else
             {
-                CmiAbort(
-                    "constructor_caller_ called with a message pointer of "
-                    "non-message type");
+                CmiAbort("constructor_caller_ called with a message pointer of "
+                         "non-message type");
             }
         }
     };
@@ -75,10 +104,10 @@ namespace cmk {
         constructor_caller_<T, Arg>()(self, std::move(msg));
     }
 
-    template <typename T, T t>
+    template <auto Fn>
     entry_id_t entry(void)
     {
-        return entry_fn_impl_<T, t>::id_();
+        return entry_fn_impl_<Fn>::id_();
     }
 
     template <typename T, typename Message>

--- a/include/charmlite/core/impl/proxy.hpp
+++ b/include/charmlite/core/impl/proxy.hpp
@@ -40,8 +40,7 @@ namespace cmk {
     void element_proxy<T>::send(
         typename cmk::extract_message<decltype(Fn)>::ptr_type&& msg) const
     {
-        new (&(msg->dst_))
-            destination(this->id_, this->idx_, entry<decltype(Fn), Fn>());
+        new (&(msg->dst_)) destination(this->id_, this->idx_, entry<Fn>());
         msg->sender_pe_ = CmiMyPe();
         cmk::send(std::move(msg));
     }
@@ -51,7 +50,7 @@ namespace cmk {
     auto element_proxy<T>::callback(void) const
     {
         return cmk::callback<typename cmk::extract_message<decltype(Fn)>::type>(
-            this->id_, this->idx_, entry<decltype(Fn), Fn>());
+            this->id_, this->idx_, entry<Fn>());
     }
 
     template <typename T>

--- a/include/charmlite/core/proxy.hpp
+++ b/include/charmlite/core/proxy.hpp
@@ -134,8 +134,8 @@ namespace cmk {
         {
             using message_t = typename cmk::extract_message<decltype(Fn)>::type;
 
-            return cmk::callback<message_t>(this->id_,
-                cmk::helper_::chare_bcast_root_, entry<decltype(Fn), Fn>());
+            return cmk::callback<message_t>(
+                this->id_, cmk::helper_::chare_bcast_root_, entry<Fn>());
         }
 
         // template <typename Message, member_fn_t<T, Message> Fn>
@@ -144,8 +144,8 @@ namespace cmk {
             typename cmk::extract_message<decltype(Fn)>::ptr_type&& msg) const
         {
             // send a message to the broadcast root
-            new (&msg->dst_) destination(this->id_,
-                cmk::helper_::chare_bcast_root_, entry<decltype(Fn), Fn>());
+            new (&msg->dst_) destination(
+                this->id_, cmk::helper_::chare_bcast_root_, entry<Fn>());
             cmk::send(std::move(msg));
         }
 

--- a/include/charmlite/utilities/traits.hpp
+++ b/include/charmlite/utilities/traits.hpp
@@ -28,6 +28,7 @@ namespace cmk {
     {
         using type = Message;
         using ptr_type = message_ptr<Message>;
+        using template_t = T;
     };
 
     template <typename Message>
@@ -35,6 +36,16 @@ namespace cmk {
     {
         using type = Message;
         using ptr_type = message_ptr<Message>;
+    };
+
+    template <typename T>
+    struct is_member_fn_t : std::false_type
+    {
+    };
+
+    template <typename T, typename Message>
+    struct is_member_fn_t<member_fn_t<T, Message>> : std::true_type
+    {
     };
 
 }    // namespace cmk


### PR DESCRIPTION
This PR uplifts `entry_fn_*` functions to use `template <auto>`. While this doesn't change any user-facing APIs, we can easily utilize `if constexpr` based solution to parameter marshaling using this.