### PR TITLE
Parameter marshalling support to Charmlite

### DIFF
--- a/include/charmlite/charmlite.hpp
+++ b/include/charmlite/charmlite.hpp
@@ -8,6 +8,8 @@
 #include <charmlite/utilities/math.hpp>
 #include <charmlite/utilities/traits.hpp>
 
+#include <charmlite/serialization/serialization.hpp>
+
 #if CMK_SMP
 extern int userDrivenMode;
 extern int CharmLibInterOperate;

--- a/include/charmlite/core/ep.hpp
+++ b/include/charmlite/core/ep.hpp
@@ -27,20 +27,121 @@ namespace cmk {
     template <auto Fn>
     struct entry_fn_impl_
     {
+    private:
+        template <typename... Args_>
+        static void func_invoker_impl_helper(void* self, Args_&&... args)
+        {
+            using template_t =
+                typename cmk::generate_marshall_msg<decltype(Fn)>::template_t;
+            (static_cast<template_t*>(self)->*Fn)(std::forward<Args_>(args)...);
+        }
+
+        template <typename Tuple, std::size_t... Indices>
+        static void func_invoker_impl(
+            void* self, Tuple&& t, std::index_sequence<Indices...>)
+        {
+            func_invoker_impl_helper(
+                self, std::get<Indices>(std::forward<Tuple>(t))...);
+        }
+
+        template <typename Tuple>
+        static void func_invoker(void* self, Tuple&& t)
+        {
+            func_invoker_impl(self, std::forward<Tuple>(t),
+                std::make_index_sequence<
+                    std::tuple_size<std::decay_t<Tuple>>::value>());
+        }
+
+        template <typename Serializer, typename T1, typename... Ts>
+        static void args_unfolder_impl_helper(
+            Serializer&& serializer, T1&& t1, Ts&&... ts)
+        {
+            serializer | (typename std::decay_t<T1>&) t1;
+
+            args_unfolder_impl_helper(
+                std::forward<Serializer>(serializer), std::forward<Ts>(ts)...);
+        }
+
+        template <typename Serializer, typename T1>
+        static void args_unfolder_impl_helper(Serializer&& serializer, T1&& t1)
+        {
+            serializer | (typename std::decay_t<T1>&) t1;
+        }
+
+        template <typename Serializer, typename Tuple, std::size_t... Indices>
+        static void args_unfolder_impl(
+            Serializer&& serializer, Tuple&& t, std::index_sequence<Indices...>)
+        {
+            args_unfolder_impl_helper(std::forward<Serializer>(serializer),
+                std::get<Indices>(std::forward<Tuple>(t))...);
+        }
+
+        template <typename Serializer, typename Tuple>
+        static void args_unfolder(Serializer&& serializer, Tuple&& ts)
+        {
+            using tuple_s = std::tuple_size<typename std::decay<Tuple>::type>;
+
+            args_unfolder_impl(std::forward<Serializer>(serializer),
+                std::forward<Tuple>(ts),
+                std::make_index_sequence<tuple_s::value>());
+        }
+
+    public:
         static void call_(void* self, message_ptr<>&& msg)
         {
-            if constexpr (cmk::is_member_fn_t<decltype(Fn)>::value &&
-                cmk::is_message<
-                    typename cmk::extract_message<decltype(Fn)>::type>::value)
+            if constexpr (cmk::is_member_fn_t<decltype(Fn)>::value)
+            {
+                if constexpr (cmk::is_message<typename cmk::extract_message<
+                                  decltype(Fn)>::type>::value)
+                {
+                    using message_t =
+                        typename cmk::extract_message<decltype(Fn)>::type;
+                    using template_t =
+                        typename cmk::extract_message<decltype(Fn)>::template_t;
+
+                    auto* typed = static_cast<message_t*>(msg.release());
+                    message_ptr<message_t> owned(typed);
+                    (static_cast<template_t*>(self)->*Fn)(std::move(owned));
+                }
+                else
+                {
+                    CmiAbort("entry_fn_impl_::call_ called with incompatible "
+                             "message type");
+                }
+            }
+            else if constexpr (cmk::is_member_fn_args_t<decltype(Fn)>::value)
             {
                 using message_t =
-                    typename cmk::extract_message<decltype(Fn)>::type;
-                using template_t =
-                    typename cmk::extract_message<decltype(Fn)>::template_t;
+                    typename cmk::generate_marshall_msg<decltype(Fn)>::type;
+                using tuple_t = typename cmk::generate_marshall_msg<
+                    decltype(Fn)>::tuple_type;
 
                 auto* typed = static_cast<message_t*>(msg.release());
-                message_ptr<message_t> owned(typed);
-                (static_cast<template_t*>(self)->*Fn)(std::move(owned));
+                tuple_t t{};
+
+                // Unpack to tuple_t
+                PUP::fromMem unpacker((char*) (typed) + sizeof(message));
+                args_unfolder(unpacker, t);
+
+                func_invoker(self, t);
+            }
+            else
+            {
+                using message_t =
+                    typename cmk::generate_marshall_msg<decltype(Fn)>::type;
+                using tuple_t = typename cmk::generate_marshall_msg<
+                    decltype(Fn)>::tuple_type;
+
+                auto* typed = static_cast<message_t*>(msg.release());
+                tuple_t t{};
+
+                // Unpack to tuple_t
+                PUP::fromMem unpacker((char*) (typed) + sizeof(message));
+                args_unfolder(unpacker, t);
+
+                func_invoker(self, t);
+
+                CmiAbort("no matching call to compatible functiono call.");
             }
         }
 
@@ -55,7 +156,14 @@ namespace cmk {
     {
         auto operator()(void* self, message_ptr<>&& msg)
         {
-            if constexpr (cmk::message_compatibility_v<Argument>)
+            if constexpr (cmk::is_marshall_type_v<Argument>)
+            {
+                using Message = cmk::get_message_t<Argument>;
+                auto* typed = static_cast<Message*>(msg.release());
+                message_ptr<Message> owned(typed);
+                new (static_cast<Chare*>(self)) Chare(std::move(owned));
+            }
+            else if constexpr (cmk::message_compatibility_v<Argument>)
             {
                 using Message = cmk::get_message_t<Argument>;
                 auto* typed = static_cast<Message*>(msg.release());

--- a/include/charmlite/core/impl/message.hpp
+++ b/include/charmlite/core/impl/message.hpp
@@ -59,7 +59,7 @@ namespace cmk {
     {
         return this->flags_[createhere_];
     }
- 
+
     inline message::flag_type message::is_forwarded(void)
     {
         return this->flags_[is_forwarded_];
@@ -69,7 +69,7 @@ namespace cmk {
     {
         return this->flags_[is_forwarded_];
     }
- 
+
     inline message::flag_type message::has_continuation(void)
     {
         return this->flags_[has_continuation_];

--- a/include/charmlite/core/impl/proxy.hpp
+++ b/include/charmlite/core/impl/proxy.hpp
@@ -23,23 +23,18 @@ namespace cmk {
             cmk::send(std::move(msg), pe);
     }
 
-    // template <typename T>
-    // template <typename... Args>
-    // void element_proxy<T>::insert(Args... args, int pe) const
-    // {
-    //     CmiAssertMsg(pe < CmiNumPes(), "invalid pe value passed!");
+    template <typename T>
+    template <typename... Args>
+    void element_proxy<T>::insert(Args... args) const
+    {
+        auto msg =
+            cmk::marshall_msg<Args...>::pack(std::forward<Args>(args)...);
 
-    //     auto msg =
-    //         cmk::marshall_msg<Args...>::pack(std::forward<Args>(args)...);
-
-    //     new (&(msg->dst_)) destination(
-    //         this->id_, this->idx_, constructor<T, decltype(msg)&&>());
-    //     cmk::system_detector_()->produce(this->id_, 1);
-    //     if (pe < 0)
-    //         cmk::send(std::move(msg));
-    //     else
-    //         cmk::send(std::move(msg), pe);
-    // }
+        new (&(msg->dst_)) destination(
+            this->id_, this->idx_, constructor<T, decltype(msg)&&>());
+        cmk::system_detector_()->produce(this->id_, 1);
+        cmk::send(std::move(msg));
+    }
 
     template <typename T>
     void element_proxy<T>::insert(int pe) const

--- a/include/charmlite/core/proxy.hpp
+++ b/include/charmlite/core/proxy.hpp
@@ -88,7 +88,7 @@ namespace cmk {
         void insert(message_ptr<Message>&& msg, int pe = -1) const;
 
         template <typename... Args>
-        void insert(Args... args, int pe = -1) const;
+        void insert(Args... args) const;
 
         void insert(int pe = -1) const;
 

--- a/include/charmlite/core/proxy.hpp
+++ b/include/charmlite/core/proxy.hpp
@@ -87,12 +87,19 @@ namespace cmk {
         template <typename Message>
         void insert(message_ptr<Message>&& msg, int pe = -1) const;
 
+        template <typename... Args>
+        void insert(Args... args, int pe = -1) const;
+
         void insert(int pe = -1) const;
 
         // template <typename Message, member_fn_t<T, Message> Fn>
         template <auto Fn>
         void send(
             typename cmk::extract_message<decltype(Fn)>::ptr_type&& msg) const;
+
+        // Unmarshalled message types
+        template <auto Fn, typename... Args>
+        void send(Args&&... args) const;
 
         // template <typename Message, member_fn_t<T, Message> Fn>
         template <auto Fn>
@@ -143,6 +150,18 @@ namespace cmk {
         void broadcast(
             typename cmk::extract_message<decltype(Fn)>::ptr_type&& msg) const
         {
+            // send a message to the broadcast root
+            new (&msg->dst_) destination(
+                this->id_, cmk::helper_::chare_bcast_root_, entry<Fn>());
+            cmk::send(std::move(msg));
+        }
+
+        template <auto Fn, typename... Args>
+        void broadcast(Args&&... args) const
+        {
+            auto msg =
+                cmk::marshall_msg<Args...>::pack(std::forward<Args>(args)...);
+
             // send a message to the broadcast root
             new (&msg->dst_) destination(
                 this->id_, cmk::helper_::chare_bcast_root_, entry<Fn>());

--- a/include/charmlite/serialization/marshall_message.hpp
+++ b/include/charmlite/serialization/marshall_message.hpp
@@ -26,15 +26,17 @@ namespace cmk {
         }
 
         template <typename... Args_>
-        static message_ptr<marshall_msg<marshall_args>> pack(Args_&&... args)
+        static message_ptr<marshall_msg<std::decay_t<Args_>...>> pack(
+            Args_&&... args)
         {
             PUP::sizer sizer_;
             impl::args_parser(sizer_, std::forward<Args_>(args)...);
             int size = sizer_.size();
 
-            message_ptr<marshall_msg<marshall_args>> msg(
+            message_ptr<marshall_msg<std::decay_t<Args_>...>> msg(
                 new (sizeof(cmk::message) + size)
-                    marshall_msg<marshall_args>(sizeof(cmk::message) + size));
+                    marshall_msg<std::decay_t<Args_>...>(
+                        sizeof(cmk::message) + size));
 
             int msg_offset = sizeof(message);
             PUP::toMem pack_to_mem((void*) ((char*) (msg.get()) + msg_offset));

--- a/include/charmlite/serialization/marshall_message.hpp
+++ b/include/charmlite/serialization/marshall_message.hpp
@@ -52,14 +52,12 @@ namespace cmk {
             args_parser(sizer_, std::forward<Args_>(args)...);
             int size = sizer_.size();
 
-            CmiPrintf("Size of marshalled args: %d", size);
-
-            message_ptr<marshall_msg<marshall_args>> msg =
-                make_message<marshall_msg<marshall_args>>(
-                    sizeof(message) + size);
+            message_ptr<marshall_msg<marshall_args>> msg(
+                new (sizeof(cmk::message) + size)
+                    marshall_msg<marshall_args>(sizeof(cmk::message) + size));
 
             int msg_offset = sizeof(message);
-            PUP::toMem pack_to_mem((void*) (msg.get() + msg_offset));
+            PUP::toMem pack_to_mem((void*) ((char*) (msg.get()) + msg_offset));
             args_parser(pack_to_mem, std::forward<Args_>(args)...);
 
             return msg;

--- a/include/charmlite/serialization/marshall_message.hpp
+++ b/include/charmlite/serialization/marshall_message.hpp
@@ -1,0 +1,70 @@
+#ifndef CHARMLITE_SERIALIZATION_MARSHALL_MESSAGE_HPP
+#define CHARMLITE_SERIALIZATION_MARSHALL_MESSAGE_HPP
+
+#include <charmlite/core/message.hpp>
+
+#include <pup.h>
+#include <pup_stl.h>
+
+#include <cstdint>
+#include <type_traits>
+#include <utility>
+
+namespace cmk {
+
+    template <typename... Args>
+    struct marshall_msg : cmk::message
+    {
+    private:
+        template <typename Serializer, typename Arg0, typename... Args_>
+        static void args_parser(
+            Serializer&& serializer, Arg0&& arg0, Args_&&... args)
+        {
+            serializer | (typename std::decay_t<Arg0>&) arg0;
+            args_parser(std::forward<Serializer>(serializer),
+                std::forward<Args_>(args)...);
+        }
+
+        template <typename Serializer, typename Arg0>
+        static void args_parser(Serializer&& serializer, Arg0&& arg0)
+        {
+            serializer | (typename std::decay_t<Arg0>&) arg0;
+        }
+
+        template <typename Serializer>
+        static void args_parser(Serializer&&)
+        {
+        }
+
+    public:
+        using marshall_args = std::tuple<std::decay_t<Args>...>;
+
+        marshall_msg(int size)
+          : cmk::message(
+                cmk::message_helper_<marshall_msg<Args...>>::kind_, size)
+        {
+        }
+
+        template <typename... Args_>
+        static message_ptr<marshall_msg<marshall_args>> pack(Args_&&... args)
+        {
+            PUP::sizer sizer_;
+            args_parser(sizer_, std::forward<Args_>(args)...);
+            int size = sizer_.size();
+
+            CmiPrintf("Size of marshalled args: %d", size);
+
+            message_ptr<marshall_msg<marshall_args>> msg =
+                make_message<marshall_msg<marshall_args>>(
+                    sizeof(message) + size);
+
+            int msg_offset = sizeof(message);
+            PUP::toMem pack_to_mem((void*) (msg.get() + msg_offset));
+            args_parser(pack_to_mem, std::forward<Args_>(args)...);
+
+            return msg;
+        }
+    };
+}    // namespace cmk
+
+#endif

--- a/include/charmlite/serialization/serialization.hpp
+++ b/include/charmlite/serialization/serialization.hpp
@@ -1,0 +1,6 @@
+#ifndef CHARMLITE_SERIALIZATION_SERIALIZATION_HPP
+#define CHARMLITE_SERIALIZATION_SERIALIZATION_HPP
+
+#include <charmlite/serialization/marshall_message.hpp>
+
+#endif

--- a/include/charmlite/utilities/traits.hpp
+++ b/include/charmlite/utilities/traits.hpp
@@ -90,7 +90,7 @@ namespace cmk {
     };
 
     template <typename... Args>
-    struct is_marshall_type<marshall_msg<Args...>> : std::true_type
+    struct is_marshall_type<message_ptr<marshall_msg<Args...>>> : std::true_type
     {
     };
 
@@ -108,7 +108,7 @@ namespace cmk {
     };
 
     template <typename T>
-    using marshall_args_t = typename marshall_args<T>::type;
+    using marshall_args_t = typename marshall_args<T>::tuple_type;
 
 }    // namespace cmk
 

--- a/include/charmlite/utilities/traits.hpp
+++ b/include/charmlite/utilities/traits.hpp
@@ -3,6 +3,8 @@
 
 #include <charmlite/utilities/traits/message.hpp>
 
+#include <charmlite/serialization/marshall_message.hpp>
+
 namespace cmk {
 
     template <typename T>
@@ -47,6 +49,53 @@ namespace cmk {
     struct is_member_fn_t<member_fn_t<T, Message>> : std::true_type
     {
     };
+
+    template <typename T>
+    struct is_member_fn_args_t : std::false_type
+    {
+    };
+
+    template <typename T, typename... Args>
+    struct is_member_fn_args_t<member_fn_args_t<T, Args...>> : std::true_type
+    {
+    };
+
+    template <typename T>
+    struct generate_marshall_msg;
+
+    template <typename T, typename... Args>
+    struct generate_marshall_msg<member_fn_args_t<T, Args...>>
+    {
+        using type = marshall_msg<std::decay_t<Args>...>;
+        using template_t = T;
+        using tuple_type = std::tuple<std::decay_t<Args>...>;
+    };
+
+    template <typename Tuple>
+    struct decay_tuple;
+
+    template <typename... Args>
+    struct decay_tuple<std::tuple<Args...>>
+    {
+        using type = std::tuple<std::decay_t<Args>...>;
+    };
+
+    template <typename Tuple>
+    using decay_tuple_t = typename decay_tuple<Tuple>::type;
+
+    template <typename T>
+    struct is_marshall_type : std::false_type
+    {
+    };
+
+    template <typename... Args>
+    struct is_marshall_type<marshall_msg<Args...>> : std::true_type
+    {
+    };
+
+    template <typename Argument>
+    inline constexpr bool is_marshall_type_v =
+        is_marshall_type<Argument>::value;
 
 }    // namespace cmk
 

--- a/include/charmlite/utilities/traits.hpp
+++ b/include/charmlite/utilities/traits.hpp
@@ -2,6 +2,7 @@
 #define CHARMLITE_UTILITIES_TRAITS_HPP
 
 #include <charmlite/utilities/traits/message.hpp>
+#include <charmlite/utilities/traits/serialization.hpp>
 
 #include <charmlite/serialization/marshall_message.hpp>
 
@@ -96,6 +97,18 @@ namespace cmk {
     template <typename Argument>
     inline constexpr bool is_marshall_type_v =
         is_marshall_type<Argument>::value;
+
+    template <typename T>
+    struct marshall_args;
+
+    template <typename... Args>
+    struct marshall_args<marshall_msg<Args...>>
+    {
+        using tuple_type = std::tuple<std::decay_t<Args>...>;
+    };
+
+    template <typename T>
+    using marshall_args_t = typename marshall_args<T>::type;
 
 }    // namespace cmk
 

--- a/include/charmlite/utilities/traits/message.hpp
+++ b/include/charmlite/utilities/traits/message.hpp
@@ -103,6 +103,9 @@ namespace cmk {
     template <typename T, typename Message>
     using member_fn_t = void (T::*)(cmk::message_ptr<Message>&&);
 
+    template <typename T, typename... Args>
+    using member_fn_args_t = void (T::*)(Args...);
+
     using message_buffer_t = std::deque<message_ptr<message>>;
     using collection_buffer_t = std::unordered_map<collection_index_t,
         message_buffer_t, collection_index_hasher_>;

--- a/include/charmlite/utilities/traits/serialization.hpp
+++ b/include/charmlite/utilities/traits/serialization.hpp
@@ -1,0 +1,67 @@
+#ifndef CHARMLITE_UTILITIES_TRAITS_SERIALIZATION_HPP
+#define CHARMLITE_UTILITIES_TRAITS_SERIALIZATION_HPP
+
+#include <tuple>
+#include <type_traits>
+
+namespace cmk { namespace impl {
+
+    template <typename Serializer>
+    void args_parser(Serializer&&)
+    {
+    }
+
+    template <typename Serializer, typename Arg0>
+    void args_parser(Serializer&& serializer, Arg0&& arg0)
+    {
+        serializer | (typename std::decay_t<Arg0>&) arg0;
+    }
+
+    template <typename Serializer, typename Arg0, typename... Args_>
+    void args_parser(Serializer&& serializer, Arg0&& arg0, Args_&&... args)
+    {
+        serializer | (typename std::decay_t<Arg0>&) arg0;
+        args_parser(
+            std::forward<Serializer>(serializer), std::forward<Args_>(args)...);
+    }
+
+    template <typename Serializer>
+    void args_unfolder_impl_helper(Serializer&&)
+    {
+    }
+
+    template <typename Serializer, typename T1>
+    void args_unfolder_impl_helper(Serializer&& serializer, T1&& t1)
+    {
+        serializer | (typename std::decay_t<T1>&) t1;
+    }
+
+    template <typename Serializer, typename T1, typename... Ts>
+    void args_unfolder_impl_helper(Serializer&& serializer, T1&& t1, Ts&&... ts)
+    {
+        serializer | (typename std::decay_t<T1>&) t1;
+
+        args_unfolder_impl_helper(
+            std::forward<Serializer>(serializer), std::forward<Ts>(ts)...);
+    }
+
+    template <typename Serializer, typename Tuple, std::size_t... Indices>
+    void args_unfolder_impl(
+        Serializer&& serializer, Tuple&& t, std::index_sequence<Indices...>)
+    {
+        args_unfolder_impl_helper(std::forward<Serializer>(serializer),
+            std::get<Indices>(std::forward<Tuple>(t))...);
+    }
+
+    template <typename Serializer, typename Tuple>
+    void args_unfolder(Serializer&& serializer, Tuple&& ts)
+    {
+        using tuple_s = std::tuple_size<typename std::decay_t<Tuple>>;
+
+        args_unfolder_impl(std::forward<Serializer>(serializer),
+            std::forward<Tuple>(ts),
+            std::make_index_sequence<tuple_s::value>());
+    }
+}}    // namespace cmk::impl
+
+#endif

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -1,1 +1,2 @@
 add_subdirectory(indexing)
+add_subdirectory(serialization)

--- a/tests/serialization/CMakeLists.txt
+++ b/tests/serialization/CMakeLists.txt
@@ -1,0 +1,16 @@
+add_custom_target(serialization)
+
+set(TESTS
+    broadcast
+    # insert
+    # send
+)
+
+foreach(TEST ${TESTS})
+    set(_test_name ${TEST}_test)
+    add_executable(${_test_name} ${TEST}.cpp)
+    target_link_libraries(${_test_name} PRIVATE charmlite)
+    add_dependencies(serialization ${_test_name})
+    add_charmlite_test(${_test_name})    
+endforeach()
+

--- a/tests/serialization/CMakeLists.txt
+++ b/tests/serialization/CMakeLists.txt
@@ -2,8 +2,8 @@ add_custom_target(serialization)
 
 set(TESTS
     broadcast
-    # insert
-    # send
+    insert
+    send
 )
 
 foreach(TEST ${TESTS})

--- a/tests/serialization/broadcast.cpp
+++ b/tests/serialization/broadcast.cpp
@@ -20,6 +20,11 @@ struct invoker : cmk::chare<invoker, int>
             CmiPrintf("%d,", elem);
         }
         CmiPrintf("}\n");
+
+        auto cb =
+            cmk::callback<cmk::message>::construct<cmk::exit>(cmk::all::pes);
+        this->element_proxy().contribute<cmk::nop<>>(
+            cmk::make_message<cmk::message>(), cb);
     }
 };
 

--- a/tests/serialization/broadcast.cpp
+++ b/tests/serialization/broadcast.cpp
@@ -1,0 +1,47 @@
+#include <charmlite/charmlite.hpp>
+
+#include <iostream>
+#include <tuple>
+#include <type_traits>
+#include <vector>
+
+struct invoker : cmk::chare<invoker, int>
+{
+    invoker()
+    {
+        CmiPrintf("Constructor called on PE%d!\n", CmiMyPe());
+    }
+
+    void invoke(int arg0, double arg1)
+    {
+        std::cout << arg0 << std::endl;
+        std::cout << arg1 << std::endl;
+    }
+};
+
+int main(int argc, char* argv[])
+{
+    cmk::initialize(argc, argv);
+
+    if (CmiMyNode() == 0)
+    {
+        int arg0 = 42;
+        double arg1 = 3.14;
+
+        // create a collection
+        auto arr = cmk::collection_proxy<invoker>::construct();
+        // OVER DECOMPOSE!
+        auto n = 8 * CmiNumPes();
+        for (auto i = 0; i < n; i++)
+        {
+            arr[i].insert();
+        }
+        // then send 'em a buncha' messages
+        arr.broadcast<&invoker::invoke>(arg0, arg1);
+        // necessary to enable collective communication
+        arr.done_inserting();
+    }
+
+    cmk::finalize();
+    return 0;
+}

--- a/tests/serialization/broadcast.cpp
+++ b/tests/serialization/broadcast.cpp
@@ -12,10 +12,14 @@ struct invoker : cmk::chare<invoker, int>
         CmiPrintf("Constructor called on PE%d!\n", CmiMyPe());
     }
 
-    void invoke(int arg0, double arg1)
+    void invoke(int arg0, std::vector<int>& arg1)
     {
-        std::cout << arg0 << std::endl;
-        std::cout << arg1 << std::endl;
+        CmiPrintf("From PE%d, got input: %d, {", CmiMyPe(), arg0);
+        for (int elem : arg1)
+        {
+            CmiPrintf("%d,", elem);
+        }
+        CmiPrintf("}\n");
     }
 };
 
@@ -26,7 +30,7 @@ int main(int argc, char* argv[])
     if (CmiMyNode() == 0)
     {
         int arg0 = 42;
-        double arg1 = 3.14;
+        std::vector<int> arg1{1, 2, 3};
 
         // create a collection
         auto arr = cmk::collection_proxy<invoker>::construct();

--- a/tests/serialization/insert.cpp
+++ b/tests/serialization/insert.cpp
@@ -1,0 +1,38 @@
+#include <charmlite/charmlite.hpp>
+
+#include <iostream>
+#include <tuple>
+#include <type_traits>
+#include <vector>
+
+struct invoker : cmk::chare<invoker, int>
+{
+    invoker(int arg0, double arg1)
+    {
+        std::cout << arg0 << std::endl;
+        std::cout << arg1 << std::endl;
+    }
+};
+
+int main(int argc, char* argv[])
+{
+    cmk::initialize(argc, argv);
+
+    if (CmiMyNode() == 0)
+    {
+        int arg0 = 42;
+        double arg1 = 3.14;
+
+        // create a collection
+        auto arr = cmk::collection_proxy<invoker>::construct();
+        // OVER DECOMPOSE!
+        auto n = 8 * CmiNumPes();
+        for (auto i = 0; i < n; i++)
+        {
+            arr[i].insert<int, double>(arg0, arg1);
+        }
+    }
+
+    cmk::finalize();
+    return 0;
+}

--- a/tests/serialization/insert.cpp
+++ b/tests/serialization/insert.cpp
@@ -7,7 +7,7 @@
 
 struct invoker : cmk::chare<invoker, int>
 {
-    invoker(double arg0, std::vector<int> arg1)
+    invoker(double arg0, std::vector<int> const& arg1)
     {
         CmiPrintf("From PE%d, constructor input: %f, {", CmiMyPe(), arg0);
         for (int elem : arg1)

--- a/tests/serialization/insert.cpp
+++ b/tests/serialization/insert.cpp
@@ -29,7 +29,7 @@ int main(int argc, char* argv[])
         auto n = 8 * CmiNumPes();
         for (auto i = 0; i < n; i++)
         {
-            arr[i].insert<int, double>(arg0, arg1);
+            arr[i].insert(arg0, arg1);
         }
     }
 

--- a/tests/serialization/send.cpp
+++ b/tests/serialization/send.cpp
@@ -8,7 +8,7 @@
 
 struct invoker : cmk::chare<invoker, int>
 {
-    invoker(double arg0, std::vector<int> arg1)
+    invoker(double arg0, const std::vector<int>& arg1)
     {
         CmiPrintf("From PE%d, constructor input: %f, {", CmiMyPe(), arg0);
         for (int elem : arg1)

--- a/tests/serialization/send.cpp
+++ b/tests/serialization/send.cpp
@@ -1,0 +1,57 @@
+#include <charmlite/charmlite.hpp>
+
+#include <iostream>
+#include <random>
+#include <tuple>
+#include <type_traits>
+#include <vector>
+
+struct invoker : cmk::chare<invoker, int>
+{
+    invoker(double arg0, std::vector<int> arg1)
+    {
+        CmiPrintf("From PE%d, constructor input: %f, {", CmiMyPe(), arg0);
+        for (int elem : arg1)
+        {
+            CmiPrintf("%d,", elem);
+        }
+        CmiPrintf("}\n");
+
+        this->element_proxy().send<&invoker::initiate_exit>(std::rand() % 10);
+    }
+
+    void initiate_exit(int exit_code)
+    {
+        CmiPrintf("Initiating Exit from PE%d with exit code %d\n", CmiMyPe(),
+            exit_code);
+        auto cb =
+            cmk::callback<cmk::message>::construct<cmk::exit>(cmk::all::pes);
+        this->element_proxy().contribute<cmk::nop<>>(
+            cmk::make_message<cmk::message>(), cb);
+    }
+};
+
+int main(int argc, char* argv[])
+{
+    cmk::initialize(argc, argv);
+
+    if (CmiMyNode() == 0)
+    {
+        double arg0 = 3.14;
+        std::vector arg1{-1, 0, 1, 42};
+
+        // create a collection
+        auto arr = cmk::collection_proxy<invoker>::construct();
+        // OVER DECOMPOSE!
+        auto n = 8 * CmiNumPes();
+        for (auto i = 0; i < n; i++)
+        {
+            arr[i].insert(arg0, arg1);
+        }
+
+        arr.done_inserting();
+    }
+
+    cmk::finalize();
+    return 0;
+}


### PR DESCRIPTION
This PR adds support for parameter marshaling to Charmlite. Currently, the feature is not working due to various serialization/de-serialization issues.

Parameter Marshalling support has been added to:
 - [x] Send
 - [x] Broadcasts
 - [x] Constructors